### PR TITLE
fix: 32bit Python 환경 및 오프라인 설치 대응

### DIFF
--- a/check_env.bat
+++ b/check_env.bat
@@ -4,19 +4,33 @@ echo  Oracle SQL Tuner - Environment Check
 echo =====================================================
 echo.
 
-echo [1] Python
-py -3.13 --version 2>nul
-if %errorlevel% neq 0 (
-    echo    [ERROR] Python 3.13 not found in PATH
+rem 사용할 Python 결정 (32bit 우선)
+set PYTHON=
+py -3.13-32 --version >nul 2>&1
+if %errorlevel% equ 0 (
+    set PYTHON=py -3.13-32
 ) else (
-    echo    [OK]
+    py -3.13 --version >nul 2>&1
+    if %errorlevel% equ 0 set PYTHON=py -3.13
+)
+
+echo [1] Python
+if "%PYTHON%"=="" (
+    echo    [ERROR] Python 3.13을 찾을 수 없습니다
+) else (
+    %PYTHON% --version
+    echo    [OK] %PYTHON%
 )
 echo.
 
 echo [2] Required Packages
-py -3.13 -c "import PyQt6; print('   PyQt6      [OK]', PyQt6.QtCore.PYQT_VERSION_STR)" 2>nul || echo    PyQt6      [NOT INSTALLED]
-py -3.13 -c "import oracledb; print('   oracledb   [OK]', oracledb.__version__)" 2>nul || echo    oracledb   [NOT INSTALLED]
-py -3.13 -c "import sqlparse; print('   sqlparse   [OK]', sqlparse.__version__)" 2>nul || echo    sqlparse   [NOT INSTALLED]
+if not "%PYTHON%"=="" (
+    %PYTHON% -c "import PyQt6; print('   PyQt6      [OK]', PyQt6.QtCore.PYQT_VERSION_STR)" 2>nul || echo    PyQt6      [NOT INSTALLED]
+    %PYTHON% -c "import oracledb; print('   oracledb   [OK]', oracledb.__version__)" 2>nul || echo    oracledb   [NOT INSTALLED]
+    %PYTHON% -c "import sqlparse; print('   sqlparse   [OK]', sqlparse.__version__)" 2>nul || echo    sqlparse   [NOT INSTALLED]
+) else (
+    echo    Python 없음 - 패키지 확인 불가
+)
 echo.
 
 echo [3] Oracle Client
@@ -25,7 +39,7 @@ if %errorlevel% equ 0 (
     echo    [OK] sqlplus found in PATH
 ) else (
     echo    [NOT FOUND] Oracle Client not installed or not in PATH
-    echo    (At home: DB connection disabled, UI only)
+    echo    (Thin 모드로 자동 연결 시도합니다)
 )
 echo.
 

--- a/download_packages.bat
+++ b/download_packages.bat
@@ -1,44 +1,56 @@
 @echo off
 echo =====================================================
 echo  Oracle SQL Tuner - Download Packages
-echo  Run this on a PC with internet access
+echo  인터넷 되는 PC에서 실행하세요 (집 PC 등)
 echo =====================================================
 echo.
 
-for /f "tokens=2 delims= " %%v in ('python --version 2^>^&1') do set PYVER=%%v
-echo Detected Python version: %PYVER%
-
-for /f "tokens=1,2 delims=." %%a in ("%PYVER%") do set PYMAJMIN=%%a.%%b
-echo Using version parameter: %PYMAJMIN%
-echo.
-
-if not exist packages mkdir packages
-
-echo [1/2] Downloading runtime packages (win_amd64, Python %PYMAJMIN%)...
-pip download -r requirements.txt -d packages ^
-    --platform win_amd64 ^
-    --python-version %PYMAJMIN% ^
-    --only-binary :all:
-
+rem Python 확인
+py -3.13 --version >nul 2>&1
 if %errorlevel% neq 0 (
-    echo.
-    echo [ERROR] Download failed.
-    echo PyQt6 may not have wheels for Python %PYMAJMIN%.
-    echo Try changing PYMAJMIN to 3.12 in this file manually.
+    echo [ERROR] Python 3.13이 없습니다.
+    pause
+    exit /b 1
+)
+
+if not exist packages_64  mkdir packages_64
+if not exist packages_32  mkdir packages_32
+if not exist packages_build mkdir packages_build
+
+echo [1/3] 64bit 패키지 다운로드 중 (win_amd64)...
+py -3.13 -m pip download PyQt6 oracledb sqlparse ^
+    --dest packages_64 ^
+    --platform win_amd64 ^
+    --python-version 3.13 ^
+    --only-binary :all:
+if %errorlevel% neq 0 (
+    echo [ERROR] 64bit 다운로드 실패
     pause
     exit /b 1
 )
 
 echo.
-echo [2/2] Downloading PyInstaller (for EXE build)...
-if not exist packages_build mkdir packages_build
-pip download pyinstaller -d packages_build
+echo [2/3] 32bit 패키지 다운로드 중 (win32)...
+py -3.13 -m pip download PyQt6 oracledb sqlparse ^
+    --dest packages_32 ^
+    --platform win32 ^
+    --python-version 3.13 ^
+    --only-binary :all:
+if %errorlevel% neq 0 (
+    echo [ERROR] 32bit 다운로드 실패
+    pause
+    exit /b 1
+)
 
 echo.
+echo [3/3] PyInstaller 다운로드 중 (빌드용)...
+py -3.13 -m pip download pyinstaller --dest packages_build
+echo.
+
 echo =====================================================
-echo  Download complete!
-echo  Copy these folders to the office PC:
-echo    packages\       - for install.bat
-echo    packages_build\ - for build_exe.bat
+echo  완료! 아래 폴더를 회사 PC에 통째로 복사하세요:
+echo    packages_64\    - 64bit Python 환경용
+echo    packages_32\    - 32bit Python 환경용
+echo    packages_build\ - EXE 빌드용 (빌드할 PC만)
 echo =====================================================
 pause

--- a/install.bat
+++ b/install.bat
@@ -1,34 +1,62 @@
 @echo off
 echo =====================================================
 echo  Oracle SQL Tuner - Offline Install
+echo  인터넷 없는 PC에서 실행하세요
 echo =====================================================
 echo.
 
-set PACKAGES_DIR=%~dp0packages
+rem 사용할 Python 결정 (32bit 우선)
+set PYTHON=
+set ARCH=
+
+py -3.13-32 --version >nul 2>&1
+if %errorlevel% equ 0 (
+    set PYTHON=py -3.13-32
+    set ARCH=32
+    echo [INFO] 32bit Python 3.13 감지
+    goto :check_packages
+)
+
+py -3.13 --version >nul 2>&1
+if %errorlevel% equ 0 (
+    set PYTHON=py -3.13
+    set ARCH=64
+    echo [INFO] 64bit Python 3.13 감지
+    goto :check_packages
+)
+
+echo [ERROR] Python 3.13이 없습니다. python.org에서 설치하세요.
+pause
+exit /b 1
+
+:check_packages
+set PACKAGES_DIR=%~dp0packages_%ARCH%
 
 if not exist "%PACKAGES_DIR%" (
-    echo [ERROR] packages folder not found.
     echo.
-    echo On a PC with internet, run: download_packages.bat
-    echo Then copy the packages folder here and run this again.
+    echo [ERROR] %PACKAGES_DIR% 폴더가 없습니다.
     echo.
-    echo If you have internet here, run install_online.bat instead.
+    echo 인터넷 되는 PC에서 download_packages.bat 실행 후
+    echo packages_32\ 또는 packages_64\ 폴더를 이 폴더에 복사하세요.
     echo.
     pause
     exit /b 1
 )
 
-echo Installing from packages folder...
-pip install --no-index --find-links="%PACKAGES_DIR%" -r requirements.txt
+echo [INFO] %PACKAGES_DIR% 에서 설치합니다...
+echo.
+
+%PYTHON% -m pip install --no-index --find-links="%PACKAGES_DIR%" PyQt6 oracledb sqlparse
+
 if %errorlevel% neq 0 (
     echo.
-    echo [ERROR] Install failed.
+    echo [ERROR] 설치 실패. packages_%ARCH%\ 폴더 내용을 확인하세요.
     pause
     exit /b 1
 )
 
 echo.
 echo =====================================================
-echo  Install complete! Run run.bat to start.
+echo  설치 완료! run.bat으로 실행하세요.
 echo =====================================================
 pause

--- a/install_online.bat
+++ b/install_online.bat
@@ -4,17 +4,30 @@ echo  Oracle SQL Tuner - Online Install (Internet required)
 echo =====================================================
 echo.
 
-py -3.13 --version 2>nul
-if %errorlevel% neq 0 (
-    echo [ERROR] Python 3.13 not found. Please install Python 3.13 first.
-    pause
-    exit /b 1
+rem 32bit Python 우선 시도
+set PYTHON=
+py -3.13-32 --version >nul 2>&1
+if %errorlevel% equ 0 (
+    set PYTHON=py -3.13-32
+    echo [INFO] 32bit Python 3.13 감지 - 32bit 패키지를 설치합니다.
+    goto :install
 )
 
+py -3.13 --version >nul 2>&1
+if %errorlevel% equ 0 (
+    set PYTHON=py -3.13
+    echo [INFO] 64bit Python 3.13 감지 - 64bit 패키지를 설치합니다.
+    goto :install
+)
+
+echo [ERROR] Python 3.13을 찾을 수 없습니다. python.org 에서 설치하세요.
+pause
+exit /b 1
+
+:install
 echo Installing packages...
 echo.
-
-py -3.13 -m pip install PyQt6 oracledb sqlparse
+%PYTHON% -m pip install PyQt6 oracledb sqlparse
 
 if %errorlevel% neq 0 (
     echo.
@@ -27,6 +40,5 @@ echo.
 echo =====================================================
 echo  Install complete! Run run.bat to start.
 echo  Note: DB connection requires Oracle Client.
-echo        At home, only UI preview is available.
 echo =====================================================
 pause

--- a/run.bat
+++ b/run.bat
@@ -1,14 +1,26 @@
 @echo off
 cd /d "%~dp0"
 
-py -3.13 --version >nul 2>&1
-if %errorlevel% neq 0 (
-    echo [ERROR] Python 3.13 not found in PATH.
-    pause
-    exit /b 1
+rem 32bit Python 우선 시도 (32bit Oracle Client 환경 대응)
+py -3.13-32 --version >nul 2>&1
+if %errorlevel% equ 0 (
+    py -3.13-32 main.py
+    goto :check_result
 )
 
-py -3.13 main.py
+rem 64bit Python 시도
+py -3.13 --version >nul 2>&1
+if %errorlevel% equ 0 (
+    py -3.13 main.py
+    goto :check_result
+)
+
+echo [ERROR] Python 3.13을 찾을 수 없습니다.
+echo python.org 에서 Python 3.13을 설치하세요.
+pause
+exit /b 1
+
+:check_result
 if %errorlevel% neq 0 (
     echo.
     echo =====================================================


### PR DESCRIPTION
## 변경 내용
- run.bat: py -3.13-32 우선 시도 후 py -3.13 폴백
- install_online.bat: Python 아키텍처 자동 감지
- check_env.bat: 32bit/64bit 자동 감지
- download_packages.bat: 64bit·32bit 패키지 동시 다운로드
- install.bat: Python 아키텍처 감지 후 맞는 폴더에서 설치