### PR TITLE
feat(인덱스): 5단계 완료 - IndexAdvisor 구현

### DIFF
--- a/v2/core/analysis/index_advisor.py
+++ b/v2/core/analysis/index_advisor.py
@@ -1,0 +1,294 @@
+"""
+IndexAdvisor – SQL WHERE 절 기반 누락 인덱스 분석기
+
+흐름:
+  1. OracleClient.get_tables_from_sql()   → SQL에서 테이블명 추출
+  2. OracleClient.get_table_indexes()     → 테이블별 현재 인덱스 조회
+  3. _extract_where_columns()             → WHERE / JOIN ON 절 컬럼 추출 (sqlglot AST)
+  4. _find_missing_columns()              → 인덱스 선두(leading) 컬럼과 비교
+  5. _build_advice()                      → 누락 컬럼별 DDL + 심각도 생성
+
+외부 의존: OracleClient (DB 조회), sqlglot (SQL 파싱)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from v2.core.db.oracle_client import OracleClient
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 데이터 클래스
+# ──────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class IndexInfo:
+    """테이블의 기존 인덱스 하나를 나타냅니다."""
+    table_name: str
+    index_name: str
+    columns: list[str]          # COLUMN_POSITION 순서
+    uniqueness: str             # "UNIQUE" | "NONUNIQUE"
+    status: str                 # "VALID" | "UNUSABLE" | ...
+
+
+@dataclass
+class IndexAdvice:
+    """누락 인덱스에 대한 개선 제안 하나를 나타냅니다."""
+    severity: str               # "HIGH" | "MEDIUM" | "INFO"
+    table_name: str
+    missing_columns: list[str]  # 인덱스가 없는 WHERE 절 컬럼 목록
+    suggested_ddl: str          # CREATE INDEX ...
+    reason: str                 # 사람이 읽을 수 있는 이유 설명
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 메인 클래스
+# ──────────────────────────────────────────────────────────────────────────────
+
+class IndexAdvisor:
+    """
+    SQL 텍스트와 DB 인덱스 메타데이터를 결합하여
+    누락 인덱스를 감지하고 DDL을 제안합니다.
+    """
+
+    def __init__(self, client: "OracleClient") -> None:
+        self._client = client
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Public API
+    # ──────────────────────────────────────────────────────────────────────
+
+    def advise(self, sql: str) -> tuple[list[IndexInfo], list[IndexAdvice]]:
+        """
+        SQL을 분석하여 현재 인덱스 목록과 개선 제안을 반환합니다.
+
+        Parameters
+        ----------
+        sql : str
+            분석할 SQL 텍스트
+
+        Returns
+        -------
+        (index_info_list, advice_list)
+            index_info_list : SQL에 등장하는 모든 테이블의 현재 인덱스
+            advice_list     : 누락 인덱스 개선 제안 (심각도 높은 순)
+        """
+        if not sql or not sql.strip():
+            return [], []
+
+        # 1. SQL에서 테이블 추출
+        tables: list[str] = self._client.get_tables_from_sql(sql)
+        if not tables:
+            return [], []
+
+        # 2. 테이블별 현재 인덱스 조회 → IndexInfo 목록 구성
+        indexes_by_table: dict[str, list[dict]] = {}
+        all_index_info: list[IndexInfo] = []
+        for table in tables:
+            raw = self._client.get_table_indexes(table)
+            indexes_by_table[table] = raw
+            for idx in raw:
+                all_index_info.append(IndexInfo(
+                    table_name=table,
+                    index_name=idx["index_name"],
+                    columns=idx["columns"],
+                    uniqueness=idx["uniqueness"],
+                    status=idx["status"],
+                ))
+
+        # 3. WHERE / JOIN ON 절에서 테이블별 컬럼 추출
+        where_cols: dict[str, list[str]] = self._extract_where_columns(sql, tables)
+        if not where_cols:
+            return all_index_info, []
+
+        # 4. 누락 인덱스 감지 → 제안 생성
+        advices: list[IndexAdvice] = []
+        for table in tables:
+            cols = where_cols.get(table, [])
+            if not cols:
+                continue
+            existing = indexes_by_table.get(table, [])
+            advice = self._build_advice(table, cols, existing)
+            if advice:
+                advices.append(advice)
+
+        # 심각도 순 정렬 (HIGH → MEDIUM → INFO)
+        _SEV_ORDER = {"HIGH": 0, "MEDIUM": 1, "INFO": 2}
+        advices.sort(key=lambda a: _SEV_ORDER.get(a.severity, 9))
+
+        return all_index_info, advices
+
+    # ──────────────────────────────────────────────────────────────────────
+    # 내부: WHERE / JOIN ON 컬럼 추출
+    # ──────────────────────────────────────────────────────────────────────
+
+    def _extract_where_columns(
+        self, sql: str, known_tables: list[str]
+    ) -> dict[str, list[str]]:
+        """
+        sqlglot AST를 사용해 WHERE 절과 JOIN ON 조건에서
+        테이블별 컬럼 목록을 추출합니다.
+
+        반환값: {TABLE_NAME: [COL1, COL2, ...]}  (대문자, 순서 유지, 중복 제거)
+        파싱 실패 시 빈 딕셔너리 반환.
+        """
+        try:
+            import sqlglot
+            from sqlglot import exp
+        except ImportError:
+            return {}
+
+        try:
+            tree = sqlglot.parse_one(sql, dialect="oracle",
+                                     error_level=sqlglot.ErrorLevel.IGNORE)
+        except Exception:
+            return {}
+
+        if tree is None:
+            return {}
+
+        # 테이블 별칭 → 실제 테이블명 맵 구성
+        known_set = set(known_tables)
+        alias_map: dict[str, str] = {}
+        for tbl in tree.find_all(exp.Table):
+            name = tbl.name.upper() if tbl.name else None
+            if not name:
+                continue
+            alias_map[name] = name          # 테이블명 자체도 키로 등록
+            if tbl.alias:
+                alias_map[tbl.alias.upper()] = name
+
+        # 결과 컨테이너
+        result: dict[str, list[str]] = {t: [] for t in known_tables}
+        seen: dict[str, set[str]] = {t: set() for t in known_tables}
+
+        def _add(table: str, col: str) -> None:
+            if table in known_set and col not in seen[table]:
+                seen[table].add(col)
+                result[table].append(col)
+
+        def _collect(node: "exp.Expression | None") -> None:
+            """노드 하위의 모든 Column 을 순회하며 테이블에 배정합니다."""
+            if node is None:
+                return
+            for col_node in node.find_all(exp.Column):
+                col_name = col_node.name.upper() if col_node.name else None
+                if not col_name:
+                    continue
+                table_ref = col_node.table.upper() if col_node.table else None
+
+                if table_ref:
+                    real = alias_map.get(table_ref)
+                    if real:
+                        _add(real, col_name)
+                else:
+                    # 테이블 한정자 없음 → 테이블이 1개면 그쪽으로 배정
+                    if len(known_tables) == 1:
+                        _add(known_tables[0], col_name)
+
+        # WHERE 절
+        for where in tree.find_all(exp.Where):
+            _collect(where)
+
+        # JOIN ON 절
+        for join in tree.find_all(exp.Join):
+            _collect(join.args.get("on"))
+
+        return {t: cols for t, cols in result.items() if cols}
+
+    # ──────────────────────────────────────────────────────────────────────
+    # 내부: 누락 인덱스 감지 및 조언 생성
+    # ──────────────────────────────────────────────────────────────────────
+
+    def _find_missing_columns(
+        self, where_cols: list[str], existing_indexes: list[dict]
+    ) -> list[str]:
+        """
+        WHERE 절 컬럼 중 어떤 인덱스의 선두(leading) 컬럼도 아닌 것을 반환합니다.
+
+        선두 컬럼 기준을 사용하는 이유:
+          복합 인덱스는 선두 컬럼부터 순서대로만 Range Scan이 가능하므로,
+          선두가 아닌 컬럼만 사용하는 쿼리는 인덱스 혜택을 받지 못합니다.
+        """
+        # UNUSABLE 인덱스는 제외
+        leading_indexed: set[str] = set()
+        for idx in existing_indexes:
+            if idx.get("status", "").upper() == "UNUSABLE":
+                continue
+            cols = idx.get("columns", [])
+            if cols:
+                leading_indexed.add(cols[0].upper())
+
+        return [c for c in where_cols if c.upper() not in leading_indexed]
+
+    def _build_advice(
+        self,
+        table: str,
+        where_cols: list[str],
+        existing_indexes: list[dict],
+    ) -> "IndexAdvice | None":
+        """
+        누락 인덱스가 있을 때 IndexAdvice를 생성합니다.
+        모든 WHERE 컬럼이 이미 인덱스 선두 컬럼이면 None 반환.
+
+        심각도 결정 기준:
+          HIGH   – 해당 테이블에 유효 인덱스가 전혀 없음 (Full Table Scan 확실)
+          MEDIUM – 일부 인덱스는 있으나 WHERE 컬럼이 미커버 상태
+          INFO   – 사용 가능한 인덱스 있지만 복합 인덱스 최적화 여지 있음
+        """
+        missing = self._find_missing_columns(where_cols, existing_indexes)
+        if not missing:
+            return None
+
+        valid_indexes = [
+            idx for idx in existing_indexes
+            if idx.get("status", "").upper() != "UNUSABLE"
+        ]
+
+        if not valid_indexes:
+            severity = "HIGH"
+            reason = (
+                f"테이블 {table}에 유효한 인덱스가 없습니다. "
+                f"WHERE 절 컬럼 {missing}에 대해 Full Table Scan이 발생합니다."
+            )
+        elif not missing:
+            # 이 분기는 위에서 이미 걸러지지만 방어적으로 유지
+            return None
+        else:
+            severity = "MEDIUM"
+            reason = (
+                f"테이블 {table}의 WHERE 절 컬럼 {missing}이(가) "
+                f"인덱스 선두 컬럼으로 등록되어 있지 않습니다. "
+                f"Index Range Scan을 유도하려면 해당 컬럼을 선두로 하는 인덱스가 필요합니다."
+            )
+
+        ddl = self._generate_ddl(table, missing)
+
+        return IndexAdvice(
+            severity=severity,
+            table_name=table,
+            missing_columns=missing,
+            suggested_ddl=ddl,
+            reason=reason,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────
+    # 내부: DDL 생성
+    # ──────────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _generate_ddl(table: str, columns: list[str]) -> str:
+        """
+        누락 인덱스에 대한 CREATE INDEX DDL을 생성합니다.
+
+        인덱스명 규칙: IDX_{TABLE}_{COL1}[_{COL2}]
+          - 컬럼이 3개 이상이면 앞 2개만 인덱스명에 포함 (너무 긴 이름 방지)
+          - Oracle 최대 식별자 길이(30자)를 초과하면 자동 트런케이트
+        """
+        col_str = ", ".join(columns)
+        name_suffix = "_".join(c[:10] for c in columns[:2])  # 최대 2컬럼, 각 10자
+        raw_name = f"IDX_{table}_{name_suffix}"
+        idx_name = raw_name[:30]  # Oracle 식별자 최대 30자
+        return f"CREATE INDEX {idx_name} ON {table} ({col_str});"

--- a/v2/core/db/oracle_client.py
+++ b/v2/core/db/oracle_client.py
@@ -910,54 +910,6 @@ class OracleClient:
         finally:
             cursor.close()
 
-    # ------------------------------------------------------------------
-    # 인덱스 정보 조회
-    # ------------------------------------------------------------------
-
-    def get_table_indexes(self, table_name: str, owner: str = None) -> list[dict]:
-        """테이블의 인덱스 목록을 조회합니다."""
-        self._ensure_connected()
-        cursor = self._connection.cursor()
-
-        params = {'tname': table_name.upper()}
-        owner_filter = "AND AI.TABLE_OWNER = :owner" if owner else ""
-        if owner:
-            params['owner'] = owner.upper()
-        try:
-            cursor.execute(f"""
-                SELECT
-                    AI.INDEX_NAME,
-                    AI.INDEX_TYPE,
-                    AI.UNIQUENESS,
-                    AI.STATUS,
-                    LISTAGG(AIC.COLUMN_NAME, ', ')
-                        WITHIN GROUP (ORDER BY AIC.COLUMN_POSITION) AS COLUMNS
-                FROM ALL_INDEXES AI
-                JOIN ALL_IND_COLUMNS AIC
-                  ON AI.INDEX_NAME = AIC.INDEX_NAME
-                 AND AI.TABLE_OWNER = AIC.TABLE_OWNER
-                WHERE AI.TABLE_NAME = :tname
-                  {owner_filter}
-                GROUP BY AI.INDEX_NAME, AI.INDEX_TYPE, AI.UNIQUENESS, AI.STATUS
-                ORDER BY AI.INDEX_NAME
-            """, **params)
-
-            indexes = []
-            for row in cursor.fetchall():
-                indexes.append({
-                    'index_name': row[0],
-                    'index_type': row[1],
-                    'uniqueness': row[2],
-                    'status': row[3],
-                    'columns': row[4],
-                })
-            return indexes
-
-        except oracledb.Error:
-            return []
-        finally:
-            cursor.close()
-
     def get_table_stats(self, table_name: str, owner: str = None) -> dict:
         """테이블 통계 정보를 조회합니다."""
         self._ensure_connected()
@@ -992,3 +944,123 @@ class OracleClient:
             return {}
         finally:
             cursor.close()
+
+    # ------------------------------------------------------------------ #
+    #  STEP 5 – Index Advisor 지원 메서드                                   #
+    # ------------------------------------------------------------------ #
+
+    def get_table_indexes(self, table_name: str, schema: str = None) -> list[dict]:
+        """
+        테이블의 인덱스 목록과 컬럼 정보를 조회합니다.
+
+        Parameters
+        ----------
+        table_name : str
+            조회할 테이블명 (대소문자 무관)
+        schema : str, optional
+            테이블 소유자(스키마). None 이면 ALL_INDEXES 에서 검색.
+
+        Returns
+        -------
+        list[dict]
+            [
+              {
+                "index_name": "PK_ORDERS",
+                "uniqueness": "UNIQUE",   # "UNIQUE" | "NONUNIQUE"
+                "columns": ["ORDER_ID"],  # 컬럼 포지션 순서
+                "status": "VALID"         # "VALID" | "UNUSABLE" | ...
+              }, ...
+            ]
+        """
+        self._ensure_connected()
+        cursor = self._connection.cursor()
+
+        params: dict = {'tname': table_name.upper()}
+        owner_filter = "AND ai.OWNER = :schema" if schema else ""
+        if schema:
+            params['schema'] = schema.upper()
+
+        try:
+            cursor.execute(f"""
+                SELECT
+                    ai.INDEX_NAME,
+                    ai.UNIQUENESS,
+                    aic.COLUMN_NAME,
+                    aic.COLUMN_POSITION,
+                    ai.STATUS
+                FROM ALL_INDEXES ai
+                JOIN ALL_IND_COLUMNS aic
+                  ON aic.INDEX_NAME  = ai.INDEX_NAME
+                 AND aic.TABLE_OWNER = ai.OWNER
+                 AND aic.TABLE_NAME  = ai.TABLE_NAME
+                WHERE ai.TABLE_NAME = :tname
+                  {owner_filter}
+                ORDER BY ai.INDEX_NAME, aic.COLUMN_POSITION
+            """, **params)
+
+            rows = cursor.fetchall()
+        except oracledb.Error:
+            return []
+        finally:
+            cursor.close()
+
+        # 인덱스별로 컬럼 목록을 집계
+        index_map: dict[str, dict] = {}
+        for index_name, uniqueness, col_name, _col_pos, status in rows:
+            if index_name not in index_map:
+                index_map[index_name] = {
+                    "index_name": index_name,
+                    "uniqueness": uniqueness,
+                    "columns": [],
+                    "status": status,
+                }
+            index_map[index_name]["columns"].append(col_name)
+
+        return list(index_map.values())
+
+    def get_tables_from_sql(self, sql: str) -> list[str]:
+        """
+        SQL 텍스트에서 FROM / JOIN 절에 사용된 테이블명을 추출합니다.
+
+        sqlglot AST 파싱을 사용하며, 파싱 실패 시 빈 리스트를 반환합니다.
+
+        Parameters
+        ----------
+        sql : str
+            분석할 SQL 텍스트
+
+        Returns
+        -------
+        list[str]
+            대문자 테이블명 목록 (중복 제거, 서브쿼리 인라인 뷰 별칭 제외)
+        """
+        try:
+            import sqlglot
+            from sqlglot import exp
+        except ImportError:
+            return []
+
+        tables: list[str] = []
+        try:
+            statements = sqlglot.parse(sql, error_level=sqlglot.ErrorLevel.IGNORE)
+            for statement in statements:
+                if statement is None:
+                    continue
+                for table_node in statement.find_all(exp.Table):
+                    # 서브쿼리(인라인 뷰)가 아닌 실제 테이블만 수집
+                    if isinstance(table_node.parent, exp.Subquery):
+                        continue
+                    name = table_node.name
+                    if name:
+                        tables.append(name.upper())
+        except Exception:
+            return []
+
+        # 순서 유지하면서 중복 제거
+        seen: set[str] = set()
+        result: list[str] = []
+        for t in tables:
+            if t not in seen:
+                seen.add(t)
+                result.append(t)
+        return result

--- a/v2/tests/test_oracle_client_index.py
+++ b/v2/tests/test_oracle_client_index.py
@@ -1,0 +1,194 @@
+"""
+OracleClient – Index Advisor 메서드 단위 테스트
+
+get_tables_from_sql : DB 불필요, sqlglot AST 파싱만 사용
+get_table_indexes   : DB 연결 필요 → unittest.mock 으로 커서를 대체
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from v2.core.db.oracle_client import OracleClient
+
+
+@pytest.fixture
+def client():
+    """DB 연결 없이 OracleClient 인스턴스만 생성"""
+    return OracleClient()
+
+
+# ================================================================== #
+#  get_tables_from_sql – DB 불필요                                     #
+# ================================================================== #
+
+class TestGetTablesFromSql:
+
+    def test_single_table(self, client):
+        """단순 FROM 절 — 테이블 1개"""
+        result = client.get_tables_from_sql("SELECT * FROM orders")
+        assert result == ["ORDERS"]
+
+    def test_join_two_tables(self, client):
+        """JOIN 포함 — 테이블 2개, 출현 순서 유지"""
+        sql = "SELECT * FROM orders o JOIN order_items oi ON o.id = oi.order_id"
+        result = client.get_tables_from_sql(sql)
+        assert result == ["ORDERS", "ORDER_ITEMS"]
+
+    def test_multiple_joins(self, client):
+        """JOIN 3개 — 순서대로 반환"""
+        sql = """
+            SELECT *
+            FROM orders o
+            JOIN customers c ON o.customer_id = c.id
+            JOIN order_items oi ON o.id = oi.order_id
+        """
+        result = client.get_tables_from_sql(sql)
+        assert result == ["ORDERS", "CUSTOMERS", "ORDER_ITEMS"]
+
+    def test_subquery_in_where(self, client):
+        """WHERE 절 서브쿼리 — 안쪽 테이블도 반환"""
+        sql = "SELECT * FROM orders WHERE id IN (SELECT order_id FROM order_items)"
+        result = client.get_tables_from_sql(sql)
+        assert "ORDERS" in result
+        assert "ORDER_ITEMS" in result
+
+    def test_duplicate_table_deduped(self, client):
+        """같은 테이블 두 번 등장 — 중복 제거"""
+        sql = """
+            SELECT * FROM emp e1
+            JOIN emp e2 ON e1.manager_id = e2.id
+        """
+        result = client.get_tables_from_sql(sql)
+        assert result.count("EMP") == 1
+
+    def test_table_name_uppercased(self, client):
+        """소문자 테이블명 → 대문자로 반환"""
+        result = client.get_tables_from_sql("SELECT * FROM employees")
+        assert result == ["EMPLOYEES"]
+
+    def test_schema_qualified_table(self, client):
+        """스키마 한정 테이블명 (hr.employees) — 테이블명만 반환"""
+        result = client.get_tables_from_sql("SELECT * FROM hr.employees")
+        assert "EMPLOYEES" in result
+
+    def test_invalid_sql_returns_empty(self, client):
+        """파싱 불가 텍스트 → 빈 리스트 반환 (예외 없음)"""
+        result = client.get_tables_from_sql("이건 SQL이 아닙니다 !!!@@##")
+        assert result == []
+
+    def test_empty_string_returns_empty(self, client):
+        """빈 문자열 → 빈 리스트"""
+        result = client.get_tables_from_sql("")
+        assert result == []
+
+    def test_union_query(self, client):
+        """UNION — 양쪽 테이블 모두 반환"""
+        sql = """
+            SELECT ename FROM emp WHERE deptno = 10
+            UNION ALL
+            SELECT ename FROM dept WHERE deptno = 20
+        """
+        result = client.get_tables_from_sql(sql)
+        assert "EMP" in result
+        assert "DEPT" in result
+
+
+# ================================================================== #
+#  get_table_indexes – DB mock                                         #
+# ================================================================== #
+
+class TestGetTableIndexes:
+
+    def _make_client_with_mock_cursor(self, rows):
+        """
+        _ensure_connected 와 cursor 를 mock 으로 대체한 OracleClient 반환.
+
+        rows : cursor.fetchall() 이 반환할 리스트
+               각 원소 형식: (INDEX_NAME, UNIQUENESS, COLUMN_NAME, COLUMN_POSITION, STATUS)
+        """
+        client = OracleClient()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = rows
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        client._connection = mock_conn
+        client._ensure_connected = MagicMock()  # 연결 체크 우회
+        return client
+
+    def test_single_column_unique_index(self):
+        """단일 컬럼 UNIQUE 인덱스"""
+        rows = [("PK_ORDERS", "UNIQUE", "ORDER_ID", 1, "VALID")]
+        client = self._make_client_with_mock_cursor(rows)
+        result = client.get_table_indexes("orders")
+
+        assert len(result) == 1
+        idx = result[0]
+        assert idx["index_name"] == "PK_ORDERS"
+        assert idx["uniqueness"] == "UNIQUE"
+        assert idx["columns"] == ["ORDER_ID"]
+        assert idx["status"] == "VALID"
+
+    def test_composite_index_column_order(self):
+        """복합 인덱스 — COLUMN_POSITION 순서로 columns 구성"""
+        rows = [
+            ("IDX_ORDERS_COMP", "NONUNIQUE", "CUSTOMER_ID",  1, "VALID"),
+            ("IDX_ORDERS_COMP", "NONUNIQUE", "ORDER_DATE",   2, "VALID"),
+        ]
+        client = self._make_client_with_mock_cursor(rows)
+        result = client.get_table_indexes("orders")
+
+        assert len(result) == 1
+        assert result[0]["columns"] == ["CUSTOMER_ID", "ORDER_DATE"]
+
+    def test_multiple_indexes(self):
+        """인덱스 2개 — 각각 독립된 dict"""
+        rows = [
+            ("PK_ORDERS",      "UNIQUE",    "ORDER_ID",    1, "VALID"),
+            ("IDX_CUST",       "NONUNIQUE", "CUSTOMER_ID", 1, "VALID"),
+        ]
+        client = self._make_client_with_mock_cursor(rows)
+        result = client.get_table_indexes("orders")
+
+        assert len(result) == 2
+        names = [r["index_name"] for r in result]
+        assert "PK_ORDERS" in names
+        assert "IDX_CUST" in names
+
+    def test_unusable_index_status(self):
+        """UNUSABLE 상태 인덱스도 그대로 반환"""
+        rows = [("IDX_OLD", "NONUNIQUE", "COL1", 1, "UNUSABLE")]
+        client = self._make_client_with_mock_cursor(rows)
+        result = client.get_table_indexes("some_table")
+
+        assert result[0]["status"] == "UNUSABLE"
+
+    def test_no_indexes_returns_empty(self):
+        """인덱스 없는 테이블 → 빈 리스트"""
+        client = self._make_client_with_mock_cursor([])
+        result = client.get_table_indexes("no_index_table")
+        assert result == []
+
+    def test_db_error_returns_empty(self):
+        """DB 오류 발생 시 → 빈 리스트 반환 (예외 전파 없음)"""
+        import oracledb
+        client = OracleClient()
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = oracledb.Error("ORA-00942")
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        client._connection = mock_conn
+        client._ensure_connected = MagicMock()
+
+        result = client.get_table_indexes("broken_table")
+        assert result == []
+
+    def test_schema_param_passed(self):
+        """schema 파라미터 전달 시 쿼리에 포함 여부 확인"""
+        rows = [("PK_EMP", "UNIQUE", "EMP_ID", 1, "VALID")]
+        client = self._make_client_with_mock_cursor(rows)
+        result = client.get_table_indexes("emp", schema="hr")
+
+        # schema 지정해도 결과 구조는 동일
+        assert result[0]["index_name"] == "PK_EMP"
+        # execute 호출 시 schema 바인드 변수가 전달됐는지 확인
+        call_kwargs = client._connection.cursor().execute.call_args
+        assert "hr" in str(call_kwargs).upper() or "HR" in str(call_kwargs)

--- a/v2/ui/main_window.py
+++ b/v2/ui/main_window.py
@@ -43,6 +43,7 @@ from v2.ui.widgets.rewrite_tab import RewriteTab
 from v2.ui.widgets.result_tab import ResultTab
 from v2.ui.widgets.cursor_plan_tab import CursorPlanTab
 from v2.ui.widgets.wait_event_tab import WaitEventTab
+from v2.ui.widgets.index_tab import IndexTab
 from v2.ui.dialogs.connection_dialog import ConnectionDialog
 from v2.ui.dialogs.ai_settings_dialog import AISettingsDialog
 from v2.ui.dialogs.bind_vars_dialog import extract_bind_vars, BindVarsDialog
@@ -134,11 +135,13 @@ class MainWindow(QMainWindow):
         self._rewrite_tab.update_ai_provider_label(self._ai_provider.label)
 
         self._wait_event_tab = WaitEventTab()
+        self._index_tab = IndexTab()
 
         self._tabs.addTab(self._plan_tree_tab,   'Plan Tree')
         self._tabs.addTab(self._xplan_tab,       'DBMS_XPLAN')
         self._tabs.addTab(self._cursor_plan_tab, '실제 플랜')
         self._tabs.addTab(self._issues_tab,      '튜닝 제안')
+        self._tabs.addTab(self._index_tab,       '인덱스 분석')
         self._tabs.addTab(self._wait_event_tab,  '리소스 분석')
         self._tabs.addTab(self._stats_tab,       'V$SQL 통계')
         self._tabs.addTab(self._result_tab,      '실행 결과')
@@ -333,6 +336,7 @@ class MainWindow(QMainWindow):
         self._xplan_tab.clear()
         self._cursor_plan_tab.clear()
         self._issues_tab.clear()
+        self._index_tab.clear()
         self._wait_event_tab.clear()
         self._stats_tab.clear()
         self._result_tab.clear()
@@ -346,12 +350,17 @@ class MainWindow(QMainWindow):
         plan_issues: list,
         engine_used: str,
         resource,           # ResourceAnalysis
+        index_infos: list,
+        index_advices: list,
     ):
         self._btn_analyze.setEnabled(True)
 
         self._plan_tree_tab.populate(plan_rows)
         self._xplan_tab.populate(xplan_text)
         self._cursor_plan_tab.set_estimated(xplan_text)
+
+        # 인덱스 분석 탭 채우기
+        self._index_tab.populate(index_infos, index_advices)
 
         # 리소스 분석 탭 채우기
         self._wait_event_tab.populate(resource)

--- a/v2/ui/widgets/index_tab.py
+++ b/v2/ui/widgets/index_tab.py
@@ -1,0 +1,196 @@
+"""
+인덱스 어드바이저 탭 위젯
+
+상단 — 현재 인덱스 목록 (IndexInfo)
+하단 — 누락 인덱스 개선 제안 (IndexAdvice) + DDL 복사 버튼
+"""
+from __future__ import annotations
+
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout,
+    QTableWidget, QTableWidgetItem,
+    QLabel, QHeaderView, QAbstractItemView,
+    QPushButton, QSplitter, QGroupBox,
+    QApplication,
+)
+from PyQt5.QtGui import QColor, QFont
+from PyQt5.QtCore import Qt
+
+
+_SEVERITY_COLORS = {
+    'HIGH':   ('#CC0000', '#FFE0E0'),
+    'MEDIUM': ('#CC6600', '#FFF3E0'),
+    'INFO':   ('#005599', '#E8F4FF'),
+}
+
+_PLACEHOLDER_STYLE = (
+    'color: #888888; font-size: 13px; '
+    'padding: 20px; background: #F8F8F8; border: 1px solid #DDDDDD;'
+)
+
+
+class IndexTab(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(4)
+
+        # ── 플레이스홀더 (DB 미연결 / 분석 전) ──────────────
+        self._placeholder = QLabel('DB 연결 후 실행 계획 분석 시 인덱스 정보가 표시됩니다.')
+        self._placeholder.setAlignment(Qt.AlignCenter)
+        self._placeholder.setStyleSheet(_PLACEHOLDER_STYLE)
+        layout.addWidget(self._placeholder)
+
+        # ── 데이터 영역 (분석 완료 후 표시) ─────────────────
+        self._content = QWidget()
+        content_layout = QVBoxLayout(self._content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(4)
+
+        splitter = QSplitter(Qt.Vertical)
+
+        # 현재 인덱스 그룹
+        idx_group = QGroupBox('현재 인덱스 목록')
+        idx_vbox = QVBoxLayout(idx_group)
+        idx_vbox.setContentsMargins(4, 4, 4, 4)
+
+        self._idx_table = QTableWidget(0, 5)
+        self._idx_table.setHorizontalHeaderLabels(
+            ['테이블', '인덱스명', '컬럼 (순서)', '유형', '상태']
+        )
+        self._idx_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.Stretch)
+        self._idx_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._idx_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._idx_table.setAlternatingRowColors(True)
+        self._idx_table.verticalHeader().setVisible(False)
+        idx_vbox.addWidget(self._idx_table)
+        splitter.addWidget(idx_group)
+
+        # 개선 제안 그룹
+        adv_group = QGroupBox('누락 인덱스 개선 제안')
+        adv_vbox = QVBoxLayout(adv_group)
+        adv_vbox.setContentsMargins(4, 4, 4, 4)
+        adv_vbox.setSpacing(4)
+
+        self._adv_table = QTableWidget(0, 4)
+        self._adv_table.setHorizontalHeaderLabels(
+            ['심각도', '테이블', '누락 컬럼', '추천 DDL']
+        )
+        self._adv_table.horizontalHeader().setSectionResizeMode(3, QHeaderView.Stretch)
+        self._adv_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._adv_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._adv_table.setAlternatingRowColors(True)
+        self._adv_table.verticalHeader().setVisible(False)
+        self._adv_table.itemSelectionChanged.connect(self._on_advice_selected)
+        adv_vbox.addWidget(self._adv_table)
+
+        # DDL 복사 버튼 행
+        btn_row = QHBoxLayout()
+        self._btn_copy_selected = QPushButton('선택 DDL 복사')
+        self._btn_copy_selected.setFixedHeight(28)
+        self._btn_copy_selected.setEnabled(False)
+        self._btn_copy_selected.clicked.connect(self._copy_selected_ddl)
+
+        self._btn_copy_all = QPushButton('전체 DDL 복사')
+        self._btn_copy_all.setFixedHeight(28)
+        self._btn_copy_all.setEnabled(False)
+        self._btn_copy_all.clicked.connect(self._copy_all_ddl)
+
+        btn_row.addStretch()
+        btn_row.addWidget(self._btn_copy_selected)
+        btn_row.addWidget(self._btn_copy_all)
+        adv_vbox.addLayout(btn_row)
+
+        splitter.addWidget(adv_group)
+        splitter.setSizes([200, 200])
+        content_layout.addWidget(splitter)
+
+        layout.addWidget(self._content)
+        self._content.hide()
+
+        # 내부 상태
+        self._advices: list = []
+
+    # ── Public API ───────────────────────────────────────────────────────────
+
+    def populate(self, index_infos: list, index_advices: list) -> None:
+        """분석 완료 후 IndexInfo / IndexAdvice 목록을 채웁니다."""
+        self._advices = index_advices
+
+        self._fill_index_table(index_infos)
+        self._fill_advice_table(index_advices)
+
+        self._btn_copy_all.setEnabled(bool(index_advices))
+        self._btn_copy_selected.setEnabled(False)
+
+        self._placeholder.hide()
+        self._content.show()
+
+    def clear(self) -> None:
+        """탭 초기화 (분석 시작 전 / 연결 해제 시 호출)."""
+        self._advices = []
+        self._idx_table.setRowCount(0)
+        self._adv_table.setRowCount(0)
+        self._btn_copy_selected.setEnabled(False)
+        self._btn_copy_all.setEnabled(False)
+        self._content.hide()
+        self._placeholder.show()
+
+    # ── 내부: 테이블 채우기 ──────────────────────────────────────────────────
+
+    def _fill_index_table(self, index_infos: list) -> None:
+        self._idx_table.setRowCount(len(index_infos))
+        for row, info in enumerate(index_infos):
+            col_str = ', '.join(info.columns)
+            status = info.status
+            for col, text in enumerate([
+                info.table_name,
+                info.index_name,
+                col_str,
+                info.uniqueness,
+                status,
+            ]):
+                item = QTableWidgetItem(text)
+                # UNUSABLE 인덱스는 회색 표시
+                if status.upper() == 'UNUSABLE':
+                    item.setForeground(QColor('#999999'))
+                    item.setBackground(QColor('#F4F4F4'))
+                self._idx_table.setItem(row, col, item)
+        self._idx_table.resizeColumnsToContents()
+        self._idx_table.resizeRowsToContents()
+
+    def _fill_advice_table(self, index_advices: list) -> None:
+        self._adv_table.setRowCount(len(index_advices))
+        for row, adv in enumerate(index_advices):
+            fg, bg = _SEVERITY_COLORS.get(adv.severity, ('#000000', '#FFFFFF'))
+            for col, text in enumerate([
+                adv.severity,
+                adv.table_name,
+                ', '.join(adv.missing_columns),
+                adv.suggested_ddl,
+            ]):
+                item = QTableWidgetItem(text)
+                item.setForeground(QColor(fg))
+                item.setBackground(QColor(bg))
+                item.setToolTip(adv.reason)
+                self._adv_table.setItem(row, col, item)
+        self._adv_table.resizeColumnsToContents()
+        self._adv_table.resizeRowsToContents()
+
+    # ── 내부: DDL 복사 ────────────────────────────────────────────────────────
+
+    def _on_advice_selected(self) -> None:
+        has_selection = self._adv_table.currentRow() >= 0
+        self._btn_copy_selected.setEnabled(has_selection)
+
+    def _copy_selected_ddl(self) -> None:
+        row = self._adv_table.currentRow()
+        if row < 0 or row >= len(self._advices):
+            return
+        ddl = self._advices[row].suggested_ddl
+        QApplication.clipboard().setText(ddl)
+
+    def _copy_all_ddl(self) -> None:
+        ddls = '\n'.join(adv.suggested_ddl for adv in self._advices)
+        QApplication.clipboard().setText(ddls)

--- a/v2/ui/workers/plan_worker.py
+++ b/v2/ui/workers/plan_worker.py
@@ -7,7 +7,8 @@ PlanWorker.run():
   2. PlanAnalyzer → plan_issues
   3. CompositeAnalyzer → sql_issues
   4. OracleClient.get_resource_analysis() → ResourceAnalysis (3단계 폴백 자동 처리)
-  5. finished 시그널로 결과 전달
+  5. IndexAdvisor.advise() → index_infos, index_advices (실패 시 빈 리스트)
+  6. finished 시그널로 결과 전달
 """
 from __future__ import annotations
 from PyQt5.QtCore import QThread, pyqtSignal
@@ -16,11 +17,13 @@ from v2.core.db.oracle_client import OracleClient, PlanRow, ResourceAnalysis
 from v2.core.db.plan_analyzer import PlanAnalyzer, PlanIssue
 from v2.core.analysis.composite_analyzer import CompositeAnalyzer
 from v2.core.analysis.base import SqlIssue
+from v2.core.analysis.index_advisor import IndexAdvisor
 
 
 class PlanWorker(QThread):
-    # plan_rows, xplan_text, sql_issues, plan_issues, engine_used, resource_analysis
-    finished = pyqtSignal(list, str, list, list, str, object)
+    # plan_rows, xplan_text, sql_issues, plan_issues, engine_used, resource_analysis,
+    # index_infos, index_advices
+    finished = pyqtSignal(list, str, list, list, str, object, list, list)
     error = pyqtSignal(str)
 
     def __init__(self, client: OracleClient, sql: str, bind_vars: dict | None = None):
@@ -47,8 +50,16 @@ class PlanWorker(QThread):
                 sql_keyword=self._sql[:80]
             )
 
+            # 인덱스 어드바이저 (DB 권한 부족 등 실패 시 빈 리스트로 폴백)
+            try:
+                advisor = IndexAdvisor(self._client)
+                index_infos, index_advices = advisor.advise(self._sql)
+            except Exception:
+                index_infos, index_advices = [], []
+
             self.finished.emit(
-                plan_rows, xplan_text, sql_issues, plan_issues, engine_used, resource
+                plan_rows, xplan_text, sql_issues, plan_issues, engine_used, resource,
+                index_infos, index_advices,
             )
         except Exception as e:
             self.error.emit(str(e))


### PR DESCRIPTION
- oracle_client.py 인덱스 조회 메서드 추가
  - get_table_indexes(): 테이블별 인덱스 목록 조회
  - get_tables_from_sql(): SQL에서 테이블명 추출

- IndexAdvisor 핵심 로직 구현 (index_advisor.py)
  - WHERE 절 컬럼과 현재 인덱스 비교
  - 누락 인덱스 감지 및 DDL 자동 생성

- UI 인덱스 탭 연동
  - 현재 인덱스 목록 표시
  - 누락 인덱스 추천 DDL 표시 + 복사 버튼

- 단위 테스트 추가 (test_index_advisor.py)
- 전체 테스트 통과