### PR TITLE
fix(explain_plan): ORA-00938 수정 - DBMS_XPLAN.DISPLAY 바인드 변수 제거

### DIFF
--- a/v2/core/db/oracle_client.py
+++ b/v2/core/db/oracle_client.py
@@ -398,12 +398,14 @@ class OracleClient:
                 ))
 
             # 2) 같은 statement_id로 DBMS_XPLAN 텍스트 조회 (추가 EXPLAIN PLAN 불필요)
-            cursor.execute("""
+            # ※ TABLE(pipelined_func(:bind)) 구문은 일부 Oracle 버전에서 ORA-00938 발생 →
+            #   statement_id 는 내부 고정 상수이므로 f-string으로 직접 삽입
+            cursor.execute(f"""
                 SELECT PLAN_TABLE_OUTPUT
                 FROM TABLE(DBMS_XPLAN.DISPLAY(
-                    'PLAN_TABLE', :sid, 'ALL'
+                    'PLAN_TABLE', '{statement_id}', 'ALL'
                 ))
-            """, sid=statement_id)
+            """)
             xplan_lines = [row[0] for row in cursor.fetchall()]
 
             self._connection.rollback()


### PR DESCRIPTION
TABLE(pipelined_function(:bind_var)) 구문 안에 바인드 변수를 사용하면 일부 Oracle 버전에서 파서가 인자를 미해석해 ORA-00938 발생.
statement_id는 내부 고정 상수('SQL_TUNER_PLAN')이므로 f-string으로 직접 삽입.