### PR TITLE
fix(oracle_client): oracledb import 실패 시 실제 오류 메시지 노출

### DIFF
--- a/v2/core/db/oracle_client.py
+++ b/v2/core/db/oracle_client.py
@@ -5,8 +5,10 @@ python-oracledb Thick 모드 사용 (기존 Oracle 11 클라이언트 활용)
 try:
     import oracledb
     ORACLEDB_AVAILABLE = True
-except ImportError:
+    _ORACLEDB_IMPORT_ERROR: str | None = None
+except Exception as _e:
     ORACLEDB_AVAILABLE = False
+    _ORACLEDB_IMPORT_ERROR = f'{type(_e).__name__}: {_e}'
     oracledb = None  # type: ignore
 
 import os
@@ -149,9 +151,9 @@ class OracleClient:
         DPI-1047(아키텍처 불일치) 등 실패 시 Thin 모드로 자동 전환합니다.
         """
         if not ORACLEDB_AVAILABLE:
+            detail = f'\n\n[import 오류] {_ORACLEDB_IMPORT_ERROR}' if _ORACLEDB_IMPORT_ERROR else ''
             raise RuntimeError(
-                "oracledb 패키지가 설치되어 있지 않습니다.\n"
-                "install_online.bat 또는 install.bat을 실행하세요."
+                f"oracledb 패키지를 로드할 수 없습니다.{detail}"
             )
 
         # tnsnames.ora 위치를 TNS_ADMIN으로 설정

--- a/v2/main.py
+++ b/v2/main.py
@@ -31,6 +31,14 @@ def main():
 
     _logger.info('===== Oracle SQL Tuner v2 시작 =====')
 
+    # oracledb import 가능 여부를 시작 시점에 기록
+    from v2.core.db.oracle_client import ORACLEDB_AVAILABLE, _ORACLEDB_IMPORT_ERROR
+    if ORACLEDB_AVAILABLE:
+        import oracledb
+        _logger.info('oracledb %s 로드 성공', oracledb.__version__)
+    else:
+        _logger.error('oracledb 로드 실패: %s', _ORACLEDB_IMPORT_ERROR)
+
     window = MainWindow()
     window.show()
 


### PR DESCRIPTION
- ImportError 메시지를 _ORACLEDB_IMPORT_ERROR에 저장
- connect() 호출 시 실제 import 오류 내용을 에러 팝업에 표시
- 앱 시작 시 oracledb 로드 성공/실패를 로그에 기록 → exe 실행 후 로그 파일로 정확한 원인 확인 가능