### PR TITLE
fix(build): oracledb 의존 표준 라이브러리 hiddenimports 포괄 추가

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: 패키지 설치
         run: |
           python -m pip install --upgrade pip
-          pip install PyQt5 oracledb sqlglot cryptography certifi pyinstaller
+          pip install PyQt5 oracledb sqlglot cryptography certifi typing_extensions pyinstaller
 
       - name: 의존성 import 검증 (빌드 전 사전 확인)
         run: |

--- a/v2/SQL_Tuner_v2.spec
+++ b/v2/SQL_Tuner_v2.spec
@@ -51,6 +51,16 @@ a = Analysis(
         *_oracle_hidden,
         *_crypto_hidden,
         'certifi',
+        'typing_extensions',
+        # oracledb 가 내부적으로 사용하는 표준 라이브러리
+        # (thick_impl.pyd 등 컴파일 확장은 AST 스캔 불가 → 포괄 추가)
+        'getpass', 'ssl', 'socket', 'select', 'struct',
+        'hashlib', 'hmac', 'secrets', 'array',
+        'base64', 'json', 'uuid', 'threading',
+        'collections', 'collections.abc',
+        'urllib', 'urllib.parse', 'urllib.request', 'urllib.error',
+        'email', 'email.message', 'email.parser', 'email.utils',
+        'http', 'http.client',
         # PyQt5
         'PyQt5.QtWidgets',
         'PyQt5.QtCore',


### PR DESCRIPTION
thick_impl.pyd 등 컴파일 확장은 AST 스캔 불가 → 누락 모듈이
빌드마다 하나씩 드러나는 문제.
getpass/ssl/socket/hashlib 등 oracledb가 사용하는 표준 라이브러리 전체를 hiddenimports에 추가하여 반복 수정 방지.
typing_extensions pip 설치 추가.