### PR TITLE
feat(pipeline): 튜닝 검증 파이프라인 완성 (8단계 — APPROVE/REVIEW/REJECT 자동 판정 + H…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,8 @@ SQL Tuner/
     │   ├── ai/              # AI 튜닝 (ai_provider, ai_tuner)
     │   ├── analysis/        # SQL 정적 분석 (ast, regex, composite)
     │   ├── db/              # DB 연동 (oracle_client, plan_analyzer, tns_parser)
-    │   ├── pipeline/        # 분석 파이프라인 (validation)
+    │   ├── pipeline/        # 튜닝 검증 파이프라인 (validation)
+    │   ├── report/          # HTML 리포트 생성 (tuning_report)
     │   └── rewrite/         # SQL 재작성 (ast, regex, composite)
     ├── ui/
     │   ├── main_window.py
@@ -130,8 +131,11 @@ SQL 입력창에 SQL 작성
 | 새로운 SQL 안티패턴 (AST) | `v2/core/analysis/ast_analyzer.py` |
 | 새로운 SQL 안티패턴 (정규식) | `v2/core/analysis/regex_analyzer.py` |
 | SQL 재작성 로직 | `v2/core/rewrite/` |
+| 튜닝 SQL 검증 / 자동 판정 로직 | `v2/core/pipeline/validation.py` |
+| HTML 리포트 레이아웃/내용 | `v2/core/report/tuning_report.py` |
 | 화면 레이아웃 | `v2/ui/main_window.py` |
 | 탭 위젯 | `v2/ui/widgets/` |
+| 재작성·AI튜닝·검증 탭 UI | `v2/ui/widgets/rewrite_tab.py` |
 | DB 연결 방식 | `v2/core/db/oracle_client.py` |
 | 연결 다이얼로그 | `v2/ui/dialogs/connection_dialog.py` |
 | AI 설정 | `v2/ui/dialogs/ai_settings_dialog.py` |
@@ -142,20 +146,38 @@ SQL 입력창에 SQL 작성
 > 개발 환경 설정 → [docs/SETUP.md](docs/SETUP.md)
 
 
-## 마지막 작업 현황 (2026-04-14)
-- DBA 로드맵 7단계 완료
-- 완료: STEP 7-1/7-2 (ROWNUM 페이징 안티패턴 감지)
-  - ast_analyzer.py: _check_rownum_nested_paging, _check_rownum_no_order 추가
-  - regex_analyzer.py: _check_rownum_nested_paging, _check_rownum_no_order 추가
-- 완료: STEP 7-3 (스칼라 서브쿼리 → LEFT JOIN 변환)
-  - ast_rewriter.py: _scalar_subquery_to_left_join 추가
-- 완료: STEP 7-4 (WHERE IN 서브쿼리 → JOIN 변환)
-  - ast_rewriter.py: _in_subquery_to_join 추가
-- 완료: STEP 7-5 (힌트 자동 추천 — LEADING/USE_NL/USE_HASH/INDEX)
-  - hint_advisor.py: 신규 생성 (HintSuggestion, HintAdvisor)
-  - issues_tab.py: populate_hints(), _build_hint_group() 추가
-  - main_window.py: HintAdvisor 연동
-- 완료: STEP 7-6 (인라인 뷰 힌트 — PUSH_PRED/NO_MERGE)
-  - hint_advisor.py: _suggest_inline_view, _has_filter_ancestor, _build_full_hint 추가
-- 7단계 전체 완료 — 225 passed
-- 다음 작업: 8단계 또는 신규 기능 논의
+## 마지막 작업 현황 (2026-04-15)
+
+### 8단계: 튜닝 검증 파이프라인 (8-1 ~ 8-4 + 리포트)
+
+- 완료: **8-1 TuningValidator 완성** (`v2/core/pipeline/validation.py`)
+  - `validate(original_sql, tuned_sql)` 구현
+  - EXPLAIN PLAN 실행 → 루트 Cost 비교 → PlanIssue 목록 비교
+  - SQL 전처리: 세미콜론 제거, 앞뒤 공백 제거
+  - `ValidationResult` 데이터클래스: is_valid, cost_delta_pct, resolved_issues, new_issues
+
+- 완료: **8-2 실행시간 측정** (`validation.py`, `validate_worker.py`, `rewrite_tab.py`)
+  - `validate(..., measure_time=True)` 옵션 추가
+  - `original_elapsed_ms`, `tuned_elapsed_ms`, `elapsed_delta_pct` 필드
+  - SELECT / WITH 전용 — DML은 `execute_sql()` 가드에서 거부
+  - rewrite_tab: "실행시간 측정" 체크박스 추가
+
+- 완료: **8-3 row_count_match 필드** (`validation.py`)
+  - `row_count_match: Optional[bool]` 필드 추가 (미검증 시 None)
+
+- 완료: **8-4 자동 판정** (`validation.py`)
+  - `verdict: str` 필드 — APPROVE / REVIEW / REJECT
+  - `verdict_reasons: list[str]` 필드 — 판정 근거 문자열 목록
+  - `_compute_auto_verdict()` 순수 함수 (모듈 수준, 테스트 용이)
+  - 기존 `verdict` 프로퍼티 → `quality_verdict` (INVALID/IMPROVED/WARNING 등 세분화 레이블)
+  - rewrite_tab: 판정별 색상 표시 (APPROVE=초록, REVIEW=노랑, REJECT=빨강)
+
+- 완료: **HTML 리포트 생성** (`v2/core/report/tuning_report.py` 신규)
+  - `TuningReporter.generate_html(original_sql, tuned_sql, result)` → str
+  - `TuningReporter.save_html(path, ...)` → None
+  - 섹션: 요약(SQL 나란히 + 판정 배지) / 성능 비교 테이블 / 이슈 분석 / 판정 근거
+  - 인라인 CSS — 외부 파일 없이 단독 열람 가능
+  - rewrite_tab: "리포트 저장" 버튼 → QFileDialog → webbrowser.open
+
+- 8단계 완료 — **242 passed**
+- 다음 작업: 9단계 또는 신규 기능 논의

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,8 +101,73 @@ AI API를 활용해 추가 튜닝 제안을 생성하는 모듈.
 
 ## v2/core/pipeline/validation.py
 
-분석 실행 전 SQL 유효성을 검사하는 파이프라인.
-- 빈 SQL, 위험한 DDL 패턴 등 사전 차단
+원본 SQL과 튜닝 SQL을 비교하는 검증 파이프라인.
+
+### ValidationResult 데이터클래스
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `is_valid` | bool | EXPLAIN PLAN 성공 여부 |
+| `error_message` | str | 실패 시 오류 메시지 |
+| `original_cost` | int\|None | 원본 SQL 루트 노드 Cost |
+| `tuned_cost` | int\|None | 튜닝 SQL 루트 노드 Cost |
+| `cost_delta_pct` | float\|None | Cost 변화율 (음수=감소=개선) |
+| `original_issues` | list[PlanIssue] | 원본 SQL 이슈 목록 |
+| `tuned_issues` | list[PlanIssue] | 튜닝 SQL 이슈 목록 |
+| `resolved_issues` | list[PlanIssue] | 원본에만 있던 이슈 (해소됨) |
+| `new_issues` | list[PlanIssue] | 튜닝 후 새로 생긴 이슈 |
+| `row_count_match` | bool\|None | 결과 행 수 일치 여부 (None=미검증) |
+| `original_elapsed_ms` | float\|None | 원본 실행시간 (measure_time=True 시) |
+| `tuned_elapsed_ms` | float\|None | 튜닝 실행시간 (measure_time=True 시) |
+| `elapsed_delta_pct` | float\|None | 실행시간 변화율 |
+| `original_xplan` | str | 원본 DBMS_XPLAN 텍스트 |
+| `tuned_xplan` | str | 튜닝 DBMS_XPLAN 텍스트 |
+| `verdict` | str | **자동 판정** — APPROVE / REVIEW / REJECT (`__post_init__` 자동 계산) |
+| `verdict_reasons` | list[str] | 판정 근거 문자열 목록 |
+
+### 자동 판정 규칙 (`_compute_auto_verdict`)
+
+| 판정 | 조건 |
+|------|------|
+| **REJECT** | `is_valid=False` OR `row_count_match=False` OR `cost_delta_pct > 10` OR `new_issues` 존재 |
+| **APPROVE** | 위 조건 없음 AND `cost_delta_pct ≤ -10` AND `resolved_issues ≥ 1` |
+| **REVIEW** | REJECT도 APPROVE도 아닌 경우 |
+
+### 주요 프로퍼티
+
+- `quality_verdict` : 세분화 품질 레이블 (INVALID / IMPROVED / WARNING / REGRESSED / NEUTRAL)
+- `verdict_label` : 판정 한국어 레이블 (UI 표시용)
+- `cost_summary` : Cost 비교 한 줄 요약 문자열
+- `elapsed_summary` : 실행시간 비교 한 줄 요약 문자열
+
+### TuningValidator
+
+```python
+TuningValidator(client).validate(original_sql, tuned_sql, measure_time=False)
+```
+
+- SQL 전처리: 세미콜론 제거 + 앞뒤 공백 제거
+- `measure_time=True`: `execute_sql()` 호출로 실제 실행시간 측정 (SELECT/WITH 전용)
+- DB 미연결 시 즉시 `is_valid=False` 반환
+
+---
+
+## v2/core/report/tuning_report.py
+
+튜닝 결과를 단독 열람 가능한 HTML 파일로 내보내는 모듈.
+
+- `TuningReporter.generate_html(original_sql, tuned_sql, result)` → str
+- `TuningReporter.save_html(path, original_sql, tuned_sql, result)` → None
+- 외부 CSS/JS 의존 없음 — 인라인 스타일로 완전한 단일 파일 생성
+
+### 리포트 섹션 구성
+
+| 섹션 | 내용 |
+|------|------|
+| 요약 | 판정 배지(APPROVE/REVIEW/REJECT) + 원본/튜닝 SQL 나란히 표시 |
+| 성능 비교 | Cost 원본 vs 튜닝 vs 변화율 / 실행시간(측정 시) / Row Count(검증 시) |
+| 이슈 분석 | 해소된 이슈(초록) / 신규 이슈(빨강) |
+| 판정 근거 | `verdict_reasons` 목록 |
 
 ---
 
@@ -144,7 +209,7 @@ AI API를 활용해 추가 튜닝 제안을 생성하는 모듈.
 | `xplan_tab.py` | DBMS_XPLAN 텍스트 탭 |
 | `issues_tab.py` | 튜닝 제안 탭 |
 | `wait_event_tab.py` | 리소스 분석 탭 (ResourceAnalysis 표시, 조회방법 레이블, 3단계 폴백 원인 표시) |
-| `rewrite_tab.py` | 재작성 SQL + AI 튜닝 탭 |
+| `rewrite_tab.py` | 재작성 SQL + AI 튜닝 + 검증 탭. 실행시간 측정 체크박스, 리포트 저장 버튼 포함 |
 | `stats_tab.py` | V$SQL 통계 탭 |
 | `result_tab.py` | SQL 실행 결과 탭 |
 
@@ -156,7 +221,7 @@ AI API를 활용해 추가 튜닝 제안을 생성하는 모듈.
 |------|------|
 | `plan_worker.py` | EXPLAIN PLAN + 이슈 분석 + 리소스 분석(3단계 폴백) 백그라운드 실행 |
 | `execute_worker.py` | SQL 직접 실행 백그라운드 실행 |
-| `validate_worker.py` | SQL 유효성 검사 백그라운드 실행 |
+| `validate_worker.py` | `TuningValidator.validate()` 백그라운드 실행. `measure_time` 옵션 전달 |
 | `ai_tune_worker.py` | AI 튜닝 요청 백그라운드 실행 |
 
 ---
@@ -170,3 +235,5 @@ AI API를 활용해 추가 튜닝 제안을 생성하는 모듈.
 | `test_plan_analyzer.py` | `core/db/plan_analyzer.py` |
 | `test_regex_analyzer.py` | `core/analysis/regex_analyzer.py` |
 | `test_regex_rewriter.py` | `core/rewrite/regex_rewriter.py` |
+| `test_tuning_validator.py` | `core/pipeline/validation.py` — 전처리, Cost 비교, 자동 판정(APPROVE/REVIEW/REJECT), 실행시간 |
+| `test_tuning_report.py` | `core/report/tuning_report.py` — HTML 생성, 필수 섹션, 조건부 행, 파일 저장 |

--- a/v2/README.md
+++ b/v2/README.md
@@ -76,6 +76,7 @@ docker compose up -d
 
 :: 준비 완료 대기 (DATABASE IS READY TO USE! 메시지 확인)
 docker logs -f oracle-xe
+docker run -d --name oracle-free -p 1521:1521 -e ORACLE_PASSWORD=test123 gvenzl/oracle-free:slim
 ```
 
 ### 연결 정보
@@ -88,7 +89,7 @@ docker logs -f oracle-xe
 | 유저 | system |
 | 비밀번호 | test123 |
 
-앱에서 **[DB 연결]** → TNS 직접 입력 탭 → 위 값 입력
+앱에서 **[DB 연결]** → TNS 직접 입력 탭 → 위 값 입력 localhost:1521/FREEPDB1
 
 ---
 

--- a/v2/core/pipeline/validation.py
+++ b/v2/core/pipeline/validation.py
@@ -1,23 +1,97 @@
 """
 튜닝 SQL 검증 파이프라인
 
-TuningValidator.validate(original_sql, tuned_sql) 흐름:
+TuningValidator.validate(original_sql, tuned_sql, measure_time) 흐름:
   1. tuned_sql 에 EXPLAIN PLAN 실행 → 파싱/문법 오류 감지
   2. 원본 Cost vs 튜닝 Cost 비교 (cost_delta_pct)
   3. PlanIssue 목록 비교
      - resolved_issues : 원본에 있었지만 튜닝 후 사라진 이슈
      - new_issues      : 튜닝 후 새로 생긴 이슈 (회귀)
-  4. ValidationResult 반환 — UI 가 이를 그대로 표시
+  4. measure_time=True 시 실제 SELECT 를 실행해 실행시간(ms) 측정
+  5. APPROVE / REVIEW / REJECT 자동 판정 (ValidationResult.__post_init__)
+  6. ValidationResult 반환 — UI 가 이를 그대로 표시
 
 DB 미연결 또는 EXPLAIN PLAN 권한 없음 → is_valid=False, error_message 에 이유 기록
 """
 from __future__ import annotations
+import time
 from dataclasses import dataclass, field
 from typing import Optional
 
 from ..db.oracle_client import OracleClient
 from ..db.plan_analyzer import PlanAnalyzer, PlanIssue
 
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 자동 판정 로직 (모듈 수준 순수 함수 — 테스트 용이)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _compute_auto_verdict(r: 'ValidationResult') -> tuple[str, list[str]]:
+    """
+    ValidationResult 의 필드를 기반으로 (verdict, verdict_reasons) 를 계산합니다.
+
+    REJECT 조건 (하나라도 해당하면):
+      - is_valid = False (문법 오류)
+      - row_count_match = False (결과 행 수 불일치)
+      - cost_delta_pct > 10 (비용 10% 이상 증가)
+      - new_issues 존재 (신규 이슈 발생)
+
+    APPROVE 조건 (모두 만족해야):
+      - is_valid = True
+      - cost_delta_pct <= -10 (비용 10% 이상 감소)
+      - resolved_issues 1개 이상
+      - new_issues 없음
+      - row_count_match = True 또는 None (미검증)
+
+    REVIEW: REJECT 도 APPROVE 도 아닌 경우
+    """
+    # ── REJECT ────────────────────────────────────────────────────
+    reject_reasons: list[str] = []
+
+    if not r.is_valid:
+        reject_reasons.append('문법 오류 — 실행 불가')
+    if r.row_count_match is False:
+        reject_reasons.append('결과 행 수 불일치')
+    if r.cost_delta_pct is not None and r.cost_delta_pct > 10:
+        reject_reasons.append(f'비용 +{r.cost_delta_pct:.1f}% 증가')
+    if r.new_issues:
+        reject_reasons.append(f'신규 이슈 {len(r.new_issues)}건 발생')
+
+    if reject_reasons:
+        return 'REJECT', reject_reasons
+
+    # ── APPROVE ───────────────────────────────────────────────────
+    cost_ok = r.cost_delta_pct is not None and r.cost_delta_pct <= -10
+    resolved_ok = len(r.resolved_issues) >= 1
+    row_ok = r.row_count_match is not False   # True 또는 None(미검증) 허용
+
+    if cost_ok and resolved_ok and row_ok:
+        approve_reasons: list[str] = []
+        pct = abs(r.cost_delta_pct)  # type: ignore[arg-type]
+        approve_reasons.append(f'비용 {pct:.1f}% 감소')
+        n = len(r.resolved_issues)
+        if n == 1:
+            approve_reasons.append(f'{r.resolved_issues[0].title} 이슈 해소')
+        else:
+            approve_reasons.append(f'{n}개 이슈 해소')
+        approve_reasons.append('신규 이슈 없음')
+        return 'APPROVE', approve_reasons
+
+    # ── REVIEW ────────────────────────────────────────────────────
+    review_reasons: list[str] = []
+    if r.cost_delta_pct is not None:
+        sign = '+' if r.cost_delta_pct >= 0 else ''
+        review_reasons.append(f'비용 {sign}{r.cost_delta_pct:.1f}%')
+    if r.resolved_issues:
+        review_reasons.append(f'{len(r.resolved_issues)}개 이슈 해소')
+    if not review_reasons:
+        review_reasons.append('변화 없음')
+    return 'REVIEW', review_reasons
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 데이터 클래스
+# ──────────────────────────────────────────────────────────────────────────────
 
 @dataclass
 class ValidationResult:
@@ -42,31 +116,43 @@ class ValidationResult:
     resolved_issues: list[PlanIssue] = field(default_factory=list)  # 원본에만 있던 이슈
     new_issues: list[PlanIssue] = field(default_factory=list)       # 튜닝 후 새로 생긴 이슈
 
+    # ── 결과 행 수 일치 여부 (measure_time 실행 시 채워질 수 있음) ──
+    row_count_match: Optional[bool] = None
+    # True  → 원본/튜닝 행 수 동일
+    # False → 행 수 불일치 (REJECT 조건)
+    # None  → 미검증
+
+    # ── 실행시간 비교 (measure_time=True 일 때만 채워짐) ────────────
+    original_elapsed_ms: Optional[float] = None  # 원본 SQL 실제 실행시간 (ms)
+    tuned_elapsed_ms: Optional[float] = None     # 튜닝 SQL 실제 실행시간 (ms)
+    elapsed_delta_pct: Optional[float] = None
+    # elapsed_delta_pct 해석:
+    #   음수 → 실행시간 감소 (빨라짐)
+    #   양수 → 실행시간 증가 (느려짐)
+    #   None → 측정 안 함 또는 측정 불가
+
     # ── 메타 ────────────────────────────────────────
     original_xplan: str = ''    # 원본 DBMS_XPLAN 텍스트
     tuned_xplan: str = ''       # 튜닝 DBMS_XPLAN 텍스트
 
+    # ── 자동 판정 (APPROVE / REVIEW / REJECT) — __post_init__ 에서 계산 ──
+    verdict: str = field(default='', init=False)
+    verdict_reasons: list[str] = field(default_factory=list, init=False)
+
+    def __post_init__(self):
+        self.verdict, self.verdict_reasons = _compute_auto_verdict(self)
+
     # ── 편의 프로퍼티 ────────────────────────────────
 
     @property
-    def cost_improved(self) -> bool:
-        """Cost 가 감소한 경우 True"""
-        return self.cost_delta_pct is not None and self.cost_delta_pct < 0
-
-    @property
-    def has_regression(self) -> bool:
-        """HIGH 심각도 신규 이슈가 생긴 경우 True"""
-        return any(i.severity == 'HIGH' for i in self.new_issues)
-
-    @property
-    def verdict(self) -> str:
+    def quality_verdict(self) -> str:
         """
-        종합 판정 문자열 (UI 표시용)
-          INVALID  — EXPLAIN PLAN 실패 (문법 오류 등)
-          IMPROVED — Cost 감소 + 회귀 없음
+        세분화된 품질 판정 문자열 (내부 분석용)
+          INVALID   — EXPLAIN PLAN 실패 (문법 오류 등)
+          IMPROVED  — Cost 감소 + 회귀 없음
           REGRESSED — 새로운 HIGH 이슈 발생
-          NEUTRAL  — 변화 없음 또는 판단 불가
-          WARNING  — Cost 증가이나 회귀는 없음
+          NEUTRAL   — 변화 없음 또는 판단 불가
+          WARNING   — Cost 증가이나 회귀는 없음
         """
         if not self.is_valid:
             return 'INVALID'
@@ -80,14 +166,33 @@ class ValidationResult:
 
     @property
     def verdict_label(self) -> str:
-        """판정 한국어 레이블"""
+        """자동 판정 한국어 레이블 (색상 표시용)"""
+        return {
+            'APPROVE': '✅ 승인 — 튜닝 효과 확인',
+            'REVIEW':  '🔍 검토 필요',
+            'REJECT':  '❌ 반려',
+        }.get(self.verdict, self.verdict)
+
+    @property
+    def quality_verdict_label(self) -> str:
+        """세분화 품질 판정 한국어 레이블"""
         return {
             'INVALID':   '❌ 문법 오류 — 실행 불가',
             'REGRESSED': '⚠️ 회귀 — 새로운 HIGH 이슈 발생',
             'IMPROVED':  '✅ 개선됨',
             'WARNING':   '⚠️ 주의 — Cost 증가',
             'NEUTRAL':   'ℹ️ 변화 없음',
-        }.get(self.verdict, self.verdict)
+        }.get(self.quality_verdict, self.quality_verdict)
+
+    @property
+    def cost_improved(self) -> bool:
+        """Cost 가 감소한 경우 True"""
+        return self.cost_delta_pct is not None and self.cost_delta_pct < 0
+
+    @property
+    def has_regression(self) -> bool:
+        """HIGH 심각도 신규 이슈가 생긴 경우 True"""
+        return any(i.severity == 'HIGH' for i in self.new_issues)
 
     @property
     def cost_summary(self) -> str:
@@ -102,6 +207,23 @@ class ValidationResult:
             f"({sign}{delta:.1f}%)"
         )
 
+    @property
+    def elapsed_summary(self) -> str:
+        """실행시간 비교 한 줄 요약"""
+        if self.original_elapsed_ms is None or self.tuned_elapsed_ms is None:
+            return '실행시간 정보 없음'
+        delta = self.elapsed_delta_pct
+        sign = '+' if delta >= 0 else ''
+        return (
+            f"원본 실행시간: {self.original_elapsed_ms:.1f}ms  →  "
+            f"튜닝 실행시간: {self.tuned_elapsed_ms:.1f}ms  "
+            f"({sign}{delta:.1f}%)"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 검증기
+# ──────────────────────────────────────────────────────────────────────────────
 
 class TuningValidator:
     """
@@ -112,11 +234,29 @@ class TuningValidator:
     def __init__(self, client: OracleClient):
         self._client = client
 
-    def validate(self, original_sql: str, tuned_sql: str) -> ValidationResult:
+    # ------------------------------------------------------------------
+    # SQL 전처리
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _preprocess(sql: str) -> str:
+        """세미콜론 제거 + 앞뒤 공백 제거"""
+        return sql.strip().rstrip(';').strip()
+
+    def validate(
+        self,
+        original_sql: str,
+        tuned_sql: str,
+        measure_time: bool = False,
+    ) -> ValidationResult:
         """
         두 SQL 의 실행 계획을 비교합니다.
+        measure_time=True 시 SELECT 를 직접 실행해 실행시간(ms)도 측정합니다.
         DB 미연결 또는 권한 없음 시 is_valid=False 로 반환합니다.
         """
+        original_sql = self._preprocess(original_sql)
+        tuned_sql = self._preprocess(tuned_sql)
+
         if not self._client.is_connected:
             return ValidationResult(
                 is_valid=False,
@@ -163,6 +303,30 @@ class TuningValidator:
         resolved = [i for i in original_issues if (i.category, i.title) not in tuned_keys]
         new = [i for i in tuned_issues if (i.category, i.title) not in orig_keys]
 
+        # ── 실행시간 측정 (옵션) ───────────────────
+        orig_elapsed: Optional[float] = None
+        tuned_elapsed: Optional[float] = None
+        elapsed_delta: Optional[float] = None
+
+        if measure_time:
+            orig_elapsed, err = self._measure_elapsed(original_sql)
+            if err:
+                return ValidationResult(
+                    is_valid=False,
+                    error_message=f'원본 SQL 실행시간 측정 오류:\n{err}',
+                    original_xplan=orig_xplan,
+                    tuned_xplan=tuned_xplan,
+                )
+            tuned_elapsed, err = self._measure_elapsed(tuned_sql)
+            if err:
+                return ValidationResult(
+                    is_valid=False,
+                    error_message=f'튜닝 SQL 실행시간 측정 오류:\n{err}',
+                    original_xplan=orig_xplan,
+                    tuned_xplan=tuned_xplan,
+                )
+            elapsed_delta = self._calc_delta_float(orig_elapsed, tuned_elapsed)
+
         return ValidationResult(
             is_valid=True,
             original_cost=orig_cost,
@@ -172,6 +336,9 @@ class TuningValidator:
             tuned_issues=tuned_issues,
             resolved_issues=resolved,
             new_issues=new,
+            original_elapsed_ms=orig_elapsed,
+            tuned_elapsed_ms=tuned_elapsed,
+            elapsed_delta_pct=elapsed_delta,
             original_xplan=orig_xplan,
             tuned_xplan=tuned_xplan,
         )
@@ -179,6 +346,18 @@ class TuningValidator:
     # ------------------------------------------------------------------
     # 내부 헬퍼
     # ------------------------------------------------------------------
+
+    def _measure_elapsed(self, sql: str) -> tuple[Optional[float], str]:
+        """
+        SQL 을 실행하고 (elapsed_ms, error_message) 를 반환합니다.
+        SELECT / WITH 가 아닌 DML 은 client.execute_sql() 의 가드에 의해 거부됩니다.
+        성공 시 error_message 는 빈 문자열입니다.
+        """
+        try:
+            _, _, elapsed_ms, _ = self._client.execute_sql(sql)
+            return elapsed_ms, ''
+        except Exception as e:
+            return None, str(e)
 
     @staticmethod
     def _root_cost(rows) -> Optional[int]:
@@ -191,6 +370,15 @@ class TuningValidator:
     @staticmethod
     def _calc_delta(orig: Optional[int], tuned: Optional[int]) -> Optional[float]:
         """Cost 변화율(%) 계산. 원본 Cost 가 0 이하이면 None."""
+        if orig is None or tuned is None:
+            return None
+        if orig <= 0:
+            return None
+        return round((tuned - orig) / orig * 100, 1)
+
+    @staticmethod
+    def _calc_delta_float(orig: Optional[float], tuned: Optional[float]) -> Optional[float]:
+        """실수 값의 변화율(%) 계산. 원본 값이 0 이하이면 None."""
         if orig is None or tuned is None:
             return None
         if orig <= 0:

--- a/v2/core/report/tuning_report.py
+++ b/v2/core/report/tuning_report.py
@@ -1,0 +1,290 @@
+"""
+SQL 튜닝 리포트 생성기
+
+TuningReporter.generate_html(original_sql, tuned_sql, result) → 단독 열람 가능한 HTML 문자열
+TuningReporter.save_html(path, original_sql, tuned_sql, result) → 파일 저장
+
+외부 파일 의존 없이 CSS 인라인 포함 — 브라우저로 바로 열 수 있습니다.
+"""
+from __future__ import annotations
+
+import html
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..pipeline.validation import ValidationResult
+
+
+# ── 색상 상수 ─────────────────────────────────────────────────────
+_VERDICT_COLORS: dict[str, dict[str, str]] = {
+    'APPROVE': {'bg': '#d4edda', 'fg': '#155724', 'border': '#c3e6cb', 'badge': '#28a745'},
+    'REVIEW':  {'bg': '#fff3cd', 'fg': '#856404', 'border': '#ffeeba', 'badge': '#ffc107'},
+    'REJECT':  {'bg': '#f8d7da', 'fg': '#721c24', 'border': '#f5c6cb', 'badge': '#dc3545'},
+}
+_DEFAULT_COLORS = {'bg': '#e2e3e5', 'fg': '#383d41', 'border': '#d6d8db', 'badge': '#6c757d'}
+
+_SEVERITY_COLOR: dict[str, str] = {
+    'HIGH':   '#dc3545',
+    'MEDIUM': '#fd7e14',
+    'LOW':    '#ffc107',
+    'INFO':   '#17a2b8',
+}
+
+# ── 인라인 CSS ────────────────────────────────────────────────────
+_CSS = """
+*, *::before, *::after { box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 14px; line-height: 1.6;
+  background: #f8f9fa; color: #212529;
+  margin: 0; padding: 24px;
+}
+h1 { font-size: 1.6rem; margin: 0 0 4px; }
+h2 { font-size: 1.15rem; margin: 0 0 12px; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+h3 { font-size: 1rem; margin: 12px 0 6px; }
+.meta { color: #6c757d; font-size: 0.85rem; margin-bottom: 24px; }
+section { background: #fff; border: 1px solid #dee2e6; border-radius: 8px;
+          padding: 20px 24px; margin-bottom: 20px; }
+
+/* 판정 배지 */
+.verdict-badge {
+  display: inline-block; padding: 8px 20px;
+  border-radius: 20px; font-weight: 700; font-size: 1rem;
+  letter-spacing: 0.05em; margin-bottom: 16px;
+  color: #fff;
+}
+.verdict-reasons { margin: 0 0 16px; padding: 10px 14px;
+  border-radius: 6px; font-size: 0.9rem; }
+.verdict-reasons ul { margin: 4px 0 0; padding-left: 20px; }
+.verdict-reasons li { margin-bottom: 2px; }
+
+/* SQL 나란히 */
+.sql-compare { display: flex; gap: 16px; }
+.sql-box { flex: 1; min-width: 0; }
+.sql-box h3 { font-size: 0.9rem; color: #495057; margin: 0 0 6px; }
+pre.sql {
+  background: #f1f3f5; border: 1px solid #dee2e6; border-radius: 4px;
+  padding: 12px; font-size: 0.82rem; white-space: pre-wrap; word-break: break-word;
+  margin: 0; overflow-x: auto;
+}
+
+/* 성능 테이블 */
+table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+th { background: #f1f3f5; text-align: left; padding: 8px 12px;
+     border: 1px solid #dee2e6; font-weight: 600; }
+td { padding: 8px 12px; border: 1px solid #dee2e6; }
+tr:nth-child(even) td { background: #f8f9fa; }
+.delta-good { color: #155724; font-weight: 600; }
+.delta-bad  { color: #721c24; font-weight: 600; }
+.delta-neutral { color: #495057; }
+
+/* 이슈 목록 */
+.issue-list { list-style: none; margin: 0; padding: 0; }
+.issue-list li {
+  padding: 8px 12px; border-radius: 4px; margin-bottom: 6px;
+  font-size: 0.88rem; border-left: 4px solid;
+}
+.issue-resolved { background: #d4edda; border-color: #28a745; }
+.issue-new      { background: #f8d7da; border-color: #dc3545; }
+.severity-badge {
+  display: inline-block; padding: 1px 7px; border-radius: 10px;
+  font-size: 0.75rem; font-weight: 700; color: #fff; margin-right: 6px;
+  vertical-align: middle;
+}
+.empty-note { color: #6c757d; font-style: italic; font-size: 0.88rem; }
+"""
+
+
+class TuningReporter:
+    """
+    ValidationResult 를 받아 단독 열람 가능한 HTML 리포트를 생성합니다.
+    """
+
+    def generate_html(
+        self,
+        original_sql: str,
+        tuned_sql: str,
+        result: 'ValidationResult',
+    ) -> str:
+        """완전한 HTML 문서 문자열을 반환합니다."""
+        colors = _VERDICT_COLORS.get(result.verdict, _DEFAULT_COLORS)
+        generated_at = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+        sections = [
+            self._section_summary(original_sql, tuned_sql, result, colors),
+            self._section_performance(result),
+            self._section_issues(result),
+            self._section_reasons(result, colors),
+        ]
+
+        body = '\n'.join(sections)
+        return f"""<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SQL 튜닝 리포트</title>
+  <style>{_CSS}</style>
+</head>
+<body>
+  <h1>SQL 튜닝 리포트</h1>
+  <p class="meta">생성 시각: {generated_at}</p>
+  {body}
+</body>
+</html>"""
+
+    def save_html(
+        self,
+        path: str,
+        original_sql: str,
+        tuned_sql: str,
+        result: 'ValidationResult',
+    ) -> None:
+        """HTML 리포트를 파일로 저장합니다."""
+        content = self.generate_html(original_sql, tuned_sql, result)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(content)
+
+    # ------------------------------------------------------------------
+    # 섹션 빌더
+    # ------------------------------------------------------------------
+
+    def _section_summary(
+        self,
+        original_sql: str,
+        tuned_sql: str,
+        result: 'ValidationResult',
+        colors: dict[str, str],
+    ) -> str:
+        badge_label = {
+            'APPROVE': '✅ APPROVE — 승인',
+            'REVIEW':  '🔍 REVIEW — 검토 필요',
+            'REJECT':  '❌ REJECT — 반려',
+        }.get(result.verdict, result.verdict)
+
+        orig_escaped = html.escape(original_sql)
+        tuned_escaped = html.escape(tuned_sql)
+
+        return f"""
+  <section>
+    <h2>요약</h2>
+    <span class="verdict-badge" style="background:{colors['badge']};">{badge_label}</span>
+    <div class="sql-compare">
+      <div class="sql-box">
+        <h3>원본 SQL</h3>
+        <pre class="sql">{orig_escaped}</pre>
+      </div>
+      <div class="sql-box">
+        <h3>튜닝 SQL</h3>
+        <pre class="sql">{tuned_escaped}</pre>
+      </div>
+    </div>
+  </section>"""
+
+    def _section_performance(self, result: 'ValidationResult') -> str:
+        rows: list[str] = []
+
+        # Cost 행
+        orig_cost = f"{result.original_cost:,}" if result.original_cost is not None else '—'
+        tuned_cost = f"{result.tuned_cost:,}" if result.tuned_cost is not None else '—'
+        delta_cost = self._delta_cell(result.cost_delta_pct)
+        rows.append(f'<tr><td>Cost</td><td>{orig_cost}</td><td>{tuned_cost}</td><td>{delta_cost}</td></tr>')
+
+        # 실행시간 행 (measure_time=True 시에만)
+        if result.original_elapsed_ms is not None:
+            orig_ms = f"{result.original_elapsed_ms:.1f} ms"
+            tuned_ms = f"{result.tuned_elapsed_ms:.1f} ms" if result.tuned_elapsed_ms is not None else '—'
+            delta_ms = self._delta_cell(result.elapsed_delta_pct)
+            rows.append(f'<tr><td>실행시간</td><td>{orig_ms}</td><td>{tuned_ms}</td><td>{delta_ms}</td></tr>')
+
+        # Row Count 행 (row_count_match 가 설정된 경우만)
+        if result.row_count_match is not None:
+            match_str = '일치 ✓' if result.row_count_match else '불일치 ✗'
+            match_style = 'delta-good' if result.row_count_match else 'delta-bad'
+            rows.append(
+                f'<tr><td>결과 행 수</td><td colspan="2">—</td>'
+                f'<td><span class="{match_style}">{match_str}</span></td></tr>'
+            )
+
+        table_body = '\n'.join(rows)
+        return f"""
+  <section>
+    <h2>성능 비교</h2>
+    <table>
+      <thead>
+        <tr><th>항목</th><th>원본</th><th>튜닝</th><th>변화율</th></tr>
+      </thead>
+      <tbody>
+        {table_body}
+      </tbody>
+    </table>
+  </section>"""
+
+    def _section_issues(self, result: 'ValidationResult') -> str:
+        resolved_html = self._issue_list(result.resolved_issues, 'issue-resolved')
+        new_html = self._issue_list(result.new_issues, 'issue-new')
+
+        if not result.is_valid:
+            error_escaped = html.escape(result.error_message)
+            content = f'<p style="color:#721c24;">{error_escaped}</p>'
+        else:
+            content = f"""
+      <h3>해소된 이슈 ({len(result.resolved_issues)}건)</h3>
+      {resolved_html}
+      <h3 style="margin-top:16px;">신규 이슈 ({len(result.new_issues)}건)</h3>
+      {new_html}"""
+
+        return f"""
+  <section>
+    <h2>이슈 분석</h2>
+    {content}
+  </section>"""
+
+    def _section_reasons(self, result: 'ValidationResult', colors: dict[str, str]) -> str:
+        if not result.verdict_reasons:
+            items = '<li class="empty-note">판정 근거 없음</li>'
+        else:
+            items = '\n'.join(f'<li>{html.escape(r)}</li>' for r in result.verdict_reasons)
+
+        return f"""
+  <section>
+    <h2>판정 근거</h2>
+    <div class="verdict-reasons" style="background:{colors['bg']};color:{colors['fg']};border:1px solid {colors['border']};">
+      <strong>{result.verdict}</strong>
+      <ul>{items}</ul>
+    </div>
+  </section>"""
+
+    # ------------------------------------------------------------------
+    # 유틸리티
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _delta_cell(pct: float | None) -> str:
+        """변화율을 색상 클래스가 붙은 <span> 으로 반환합니다."""
+        if pct is None:
+            return '<span class="delta-neutral">—</span>'
+        sign = '+' if pct >= 0 else ''
+        css = 'delta-bad' if pct > 0 else ('delta-good' if pct < 0 else 'delta-neutral')
+        return f'<span class="{css}">{sign}{pct:.1f}%</span>'
+
+    @staticmethod
+    def _issue_list(issues: list, css_class: str) -> str:
+        """이슈 목록을 <ul> HTML 로 변환합니다."""
+        if not issues:
+            return '<p class="empty-note">없음</p>'
+
+        items: list[str] = []
+        for issue in issues:
+            sev_color = _SEVERITY_COLOR.get(issue.severity, '#6c757d')
+            badge = (
+                f'<span class="severity-badge" style="background:{sev_color};">'
+                f'{html.escape(issue.severity)}</span>'
+            )
+            title = html.escape(issue.title)
+            desc = html.escape(issue.description) if issue.description else ''
+            detail = f' — <small>{desc}</small>' if desc else ''
+            items.append(f'<li class="{css_class}">{badge}{title}{detail}</li>')
+
+        return '<ul class="issue-list">' + '\n'.join(items) + '</ul>'

--- a/v2/test_data/docker-compose.yml
+++ b/v2/test_data/docker-compose.yml
@@ -12,4 +12,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  oracle-data:
+  oracle-data:W

--- a/v2/tests/test_tuning_report.py
+++ b/v2/tests/test_tuning_report.py
@@ -1,0 +1,133 @@
+"""
+TuningReporter 단위 테스트
+
+DB 없이 ValidationResult 를 직접 구성해 HTML 생성 결과를 검증합니다.
+"""
+import pytest
+
+from v2.core.db.plan_analyzer import PlanIssue
+from v2.core.pipeline.validation import ValidationResult
+from v2.core.report.tuning_report import TuningReporter
+
+
+# ── 헬퍼 ──────────────────────────────────────────────────────────
+
+def make_issue(title: str, severity: str = 'HIGH', category: str = 'PLAN') -> PlanIssue:
+    return PlanIssue(
+        severity=severity,
+        category=category,
+        title=title,
+        description=f'{title} 상세 설명',
+        suggestion='인덱스를 추가하세요.',
+    )
+
+
+# ── HTML 생성 + 필수 태그 포함 여부 ───────────────────────────────
+
+def test_generate_html_contains_required_sections():
+    """
+    APPROVE 판정 결과로 HTML 을 생성하고 필수 구성 요소가 포함되었는지 확인합니다.
+    - <html>, <head>, <body> 기본 구조
+    - 판정 배지 (APPROVE)
+    - 원본 / 튜닝 SQL 텍스트
+    - 성능 비교 테이블 (Cost 행)
+    - 해소된 이슈 제목
+    - 판정 근거 텍스트
+    """
+    original_sql = 'SELECT * FROM EMP WHERE DEPTNO = 10'
+    tuned_sql    = 'SELECT /*+ INDEX(EMP EMP_IDX) */ * FROM EMP WHERE DEPTNO = 10'
+
+    result = ValidationResult(
+        is_valid=True,
+        original_cost=1000,
+        tuned_cost=50,
+        cost_delta_pct=-95.0,
+        resolved_issues=[make_issue('Full Table Scan on EMP')],
+        new_issues=[],
+    )
+    # __post_init__ 이 APPROVE 를 계산했는지 확인
+    assert result.verdict == 'APPROVE'
+
+    reporter = TuningReporter()
+    html_str = reporter.generate_html(original_sql, tuned_sql, result)
+
+    # ── 기본 HTML 구조 ──
+    assert '<!DOCTYPE html>' in html_str
+    assert '<html' in html_str
+    assert '<head>' in html_str
+    assert '<body>' in html_str
+
+    # ── 판정 배지 ──
+    assert 'APPROVE' in html_str
+
+    # ── SQL 텍스트 (html.escape 후에도 검색 가능) ──
+    assert 'EMP WHERE DEPTNO = 10' in html_str
+
+    # ── 성능 비교 테이블 ──
+    assert 'Cost' in html_str
+    assert '1,000' in html_str   # original_cost 천 단위 구분자
+    assert '50' in html_str      # tuned_cost
+    assert '-95.0%' in html_str  # delta
+
+    # ── 이슈 분석 ──
+    assert 'Full Table Scan on EMP' in html_str
+    assert '해소된 이슈' in html_str
+
+    # ── 판정 근거 ──
+    assert '판정 근거' in html_str
+    assert '감소' in html_str    # '비용 95.0% 감소' 등
+    assert '신규 이슈 없음' in html_str
+
+
+def test_generate_html_reject_shows_error_message():
+    """REJECT(문법 오류) 시 오류 메시지가 HTML 에 포함되어야 한다."""
+    result = ValidationResult(
+        is_valid=False,
+        error_message='ORA-00923: FROM keyword not found where expected',
+    )
+    assert result.verdict == 'REJECT'
+
+    html_str = TuningReporter().generate_html(
+        'SELECT * FROM EMP', 'SELECT FROM EMP', result
+    )
+
+    assert 'REJECT' in html_str
+    assert 'ORA-00923' in html_str
+
+
+def test_generate_html_elapsed_row_shown_only_when_measured():
+    """실행시간은 measure_time=True 로 측정된 경우에만 표시된다."""
+    base_rows = [None]  # 더미 — ValidationResult 직접 구성
+
+    # 측정 안 한 경우
+    result_no_time = ValidationResult(is_valid=True, original_cost=100, tuned_cost=90)
+    html_no = TuningReporter().generate_html('SELECT 1 FROM DUAL', 'SELECT 1 FROM DUAL', result_no_time)
+    assert '실행시간' not in html_no
+
+    # 측정한 경우
+    result_with_time = ValidationResult(
+        is_valid=True,
+        original_cost=100,
+        tuned_cost=90,
+        original_elapsed_ms=250.5,
+        tuned_elapsed_ms=80.2,
+        elapsed_delta_pct=-67.9,
+    )
+    html_yes = TuningReporter().generate_html('SELECT 1 FROM DUAL', 'SELECT 1 FROM DUAL', result_with_time)
+    assert '실행시간' in html_yes
+    assert '250.5' in html_yes
+    assert '80.2' in html_yes
+
+
+def test_save_html_writes_file(tmp_path):
+    """save_html 이 지정 경로에 유효한 HTML 파일을 생성한다."""
+    result = ValidationResult(is_valid=True, original_cost=200, tuned_cost=180)
+    path = str(tmp_path / 'report.html')
+
+    TuningReporter().save_html(path, 'SELECT 1 FROM DUAL', 'SELECT 1 FROM DUAL', result)
+
+    with open(path, encoding='utf-8') as f:
+        content = f.read()
+
+    assert '<!DOCTYPE html>' in content
+    assert len(content) > 500   # 최소한의 내용이 있어야 함

--- a/v2/tests/test_tuning_validator.py
+++ b/v2/tests/test_tuning_validator.py
@@ -1,0 +1,285 @@
+"""
+TuningValidator 단위 테스트
+
+OracleClient 를 Mock 으로 대체해 DB 없이 검증 로직을 테스트합니다.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+from v2.core.db.oracle_client import PlanRow
+from v2.core.pipeline.validation import TuningValidator, ValidationResult
+
+
+# ── 헬퍼 ──────────────────────────────────────────────────────────
+
+
+def make_row(
+    id: int,
+    operation: str = 'SELECT STATEMENT',
+    options: str = '',
+    object_name: str = '',
+    parent_id=None,
+    cost: int = 100,
+    cardinality: int = 1000,
+    depth: int = 0,
+) -> PlanRow:
+    return PlanRow(
+        id=id,
+        parent_id=parent_id,
+        operation=operation,
+        options=options,
+        object_name=object_name,
+        cost=cost,
+        cardinality=cardinality,
+        bytes=8000,
+        cpu_cost=None,
+        io_cost=None,
+        depth=depth,
+    )
+
+
+def _make_client(orig_rows, orig_xplan='', tuned_rows=None, tuned_xplan='',
+                 tuned_side_effect=None) -> MagicMock:
+    """explain_plan 을 흉내내는 Mock OracleClient 생성"""
+    client = MagicMock()
+    client.is_connected = True
+
+    if tuned_side_effect is not None:
+        client.explain_plan.side_effect = [
+            (orig_rows, orig_xplan),
+            tuned_side_effect,
+        ]
+    else:
+        client.explain_plan.side_effect = [
+            (orig_rows, orig_xplan),
+            (tuned_rows, tuned_xplan),
+        ]
+    return client
+
+
+# ── SQL 전처리 ────────────────────────────────────────────────────
+
+
+def test_preprocess_strips_semicolon_and_whitespace():
+    """세미콜론과 공백이 제거되어야 한다"""
+    cleaned = TuningValidator._preprocess("  SELECT 1 FROM DUAL;  ")
+    assert cleaned == "SELECT 1 FROM DUAL"
+
+
+def test_preprocess_no_semicolon_unchanged():
+    sql = "SELECT * FROM EMP"
+    assert TuningValidator._preprocess(sql) == sql
+
+
+# ── 정상 비교 (cost 개선) ─────────────────────────────────────────
+
+
+def test_validate_cost_improved():
+    """튜닝 후 Cost 가 감소하면 quality_verdict=IMPROVED"""
+    orig_rows = [
+        make_row(1, 'SELECT STATEMENT', cost=200),
+        make_row(2, 'TABLE ACCESS', 'FULL', 'EMP', parent_id=1, cost=200, depth=1),
+    ]
+    tuned_rows = [
+        make_row(1, 'SELECT STATEMENT', cost=50),
+        make_row(2, 'TABLE ACCESS', 'BY INDEX ROWID', 'EMP', parent_id=1,
+                 cost=50, depth=1),
+        make_row(3, 'INDEX', 'RANGE SCAN', 'EMP_IDX', parent_id=2,
+                 cost=5, depth=2),
+    ]
+
+    client = _make_client(orig_rows, tuned_rows=tuned_rows)
+    result = TuningValidator(client).validate(
+        'SELECT * FROM EMP WHERE ID = 1',
+        'SELECT /*+ INDEX(EMP EMP_IDX) */ * FROM EMP WHERE ID = 1',
+    )
+
+    assert result.is_valid is True
+    assert result.original_cost == 200
+    assert result.tuned_cost == 50
+    assert result.cost_delta_pct == pytest.approx(-75.0)
+    assert result.quality_verdict == 'IMPROVED'
+    assert result.cost_improved is True
+
+
+def test_validate_resolved_issues_detected():
+    """원본의 FTS 이슈가 튜닝 후 사라지면 resolved_issues 에 포함"""
+    orig_rows = [
+        make_row(1, 'SELECT STATEMENT', cost=500, cardinality=100_000),
+        make_row(2, 'TABLE ACCESS', 'FULL', 'BIG_TABLE', parent_id=1,
+                 cost=500, cardinality=100_000, depth=1),
+    ]
+    tuned_rows = [
+        make_row(1, 'SELECT STATEMENT', cost=10),
+        make_row(2, 'TABLE ACCESS', 'BY INDEX ROWID', 'BIG_TABLE',
+                 parent_id=1, cost=10, depth=1),
+        make_row(3, 'INDEX', 'RANGE SCAN', 'BIG_IDX', parent_id=2,
+                 cost=3, depth=2),
+    ]
+
+    client = _make_client(orig_rows, tuned_rows=tuned_rows)
+    result = TuningValidator(client).validate(
+        'SELECT * FROM BIG_TABLE',
+        'SELECT /*+ INDEX(BIG_TABLE BIG_IDX) */ * FROM BIG_TABLE WHERE ID = 1',
+    )
+
+    assert result.is_valid is True
+    assert len(result.resolved_issues) > 0
+    assert len(result.new_issues) == 0
+
+
+# ── tuned_sql 문법 오류 ───────────────────────────────────────────
+
+
+def test_validate_tuned_sql_syntax_error():
+    """tuned_sql EXPLAIN PLAN 실패 시 is_valid=False, ORA 오류 메시지 포함"""
+    orig_rows = [make_row(1, 'SELECT STATEMENT', cost=100)]
+
+    ora_error = Exception('ORA-00923: FROM keyword not found where expected')
+    client = _make_client(orig_rows, tuned_side_effect=ora_error)
+
+    result = TuningValidator(client).validate(
+        'SELECT * FROM EMP',
+        'SELECT FROM EMP',
+    )
+
+    assert result.is_valid is False
+    assert 'ORA-00923' in result.error_message
+    assert result.quality_verdict == 'INVALID'
+    assert result.verdict == 'REJECT'
+    assert any('문법 오류' in r for r in result.verdict_reasons)
+
+
+# ── DB 미연결 ─────────────────────────────────────────────────────
+
+
+def test_validate_not_connected():
+    """DB 미연결 시 즉시 is_valid=False 반환"""
+    client = MagicMock()
+    client.is_connected = False
+
+    result = TuningValidator(client).validate('SELECT 1 FROM DUAL', 'SELECT 1 FROM DUAL')
+
+    assert result.is_valid is False
+    assert '연결' in result.error_message
+    client.explain_plan.assert_not_called()
+
+
+# ── cost_delta_pct 경계값 ─────────────────────────────────────────
+
+
+def test_validate_zero_original_cost_no_delta():
+    """원본 Cost 가 0 이면 cost_delta_pct = None"""
+    orig_rows = [make_row(1, 'SELECT STATEMENT', cost=0)]
+    tuned_rows = [make_row(1, 'SELECT STATEMENT', cost=10)]
+
+    client = _make_client(orig_rows, tuned_rows=tuned_rows)
+    result = TuningValidator(client).validate('SELECT 1 FROM DUAL', 'SELECT 1 FROM DUAL')
+
+    assert result.cost_delta_pct is None
+    assert result.quality_verdict == 'NEUTRAL'
+
+
+def test_validate_cost_increase_verdict_warning():
+    """튜닝 후 Cost 100% 증가 → quality_verdict=WARNING, verdict=REJECT"""
+    orig_rows = [make_row(1, 'SELECT STATEMENT', cost=100)]
+    tuned_rows = [make_row(1, 'SELECT STATEMENT', cost=200)]
+
+    client = _make_client(orig_rows, tuned_rows=tuned_rows)
+    result = TuningValidator(client).validate('SELECT 1 FROM DUAL', 'SELECT 1 FROM DUAL')
+
+    assert result.cost_delta_pct == pytest.approx(100.0)
+    assert result.quality_verdict == 'WARNING'
+    assert result.verdict == 'REJECT'
+    assert any('증가' in r for r in result.verdict_reasons)
+
+
+# ── measure_time 기본값 (False) ───────────────────────────────────
+
+
+def test_validate_measure_time_false_no_elapsed():
+    """measure_time=False(기본값) 시 elapsed 필드가 모두 None 이어야 한다"""
+    orig_rows = [make_row(1, 'SELECT STATEMENT', cost=100)]
+    tuned_rows = [make_row(1, 'SELECT STATEMENT', cost=80)]
+
+    client = _make_client(orig_rows, tuned_rows=tuned_rows)
+    result = TuningValidator(client).validate('SELECT 1 FROM DUAL', 'SELECT 1 FROM DUAL')
+
+    assert result.original_elapsed_ms is None
+    assert result.tuned_elapsed_ms is None
+    assert result.elapsed_delta_pct is None
+    client.execute_sql.assert_not_called()
+
+
+# ── 세미콜론 포함 SQL ─────────────────────────────────────────────
+
+
+def test_validate_semicolon_in_sql_is_stripped():
+    """세미콜론 포함 SQL 도 explain_plan 에 정상 전달(세미콜론 없이)"""
+    orig_rows = [make_row(1, 'SELECT STATEMENT', cost=100)]
+    tuned_rows = [make_row(1, 'SELECT STATEMENT', cost=80)]
+
+    client = _make_client(orig_rows, tuned_rows=tuned_rows)
+    TuningValidator(client).validate('SELECT 1 FROM DUAL;', 'SELECT 1 FROM DUAL;')
+
+    for call in client.explain_plan.call_args_list:
+        sql_arg = call[0][0]
+        assert not sql_arg.endswith(';'), f"세미콜론이 남아 있음: {sql_arg!r}"
+
+
+# ── 자동 판정 (APPROVE / REVIEW / REJECT) ────────────────────────
+
+
+def test_auto_verdict_approve():
+    """비용 10% 이상 감소 + 이슈 해소 + 신규 이슈 없음 → APPROVE"""
+    # 원본: 대형 FTS (이슈 발생)
+    orig_rows = [
+        make_row(1, 'SELECT STATEMENT', cost=1000, cardinality=100_000),
+        make_row(2, 'TABLE ACCESS', 'FULL', 'BIG_TABLE', parent_id=1,
+                 cost=1000, cardinality=100_000, depth=1),
+    ]
+    # 튜닝: INDEX RANGE SCAN (이슈 없음, cost -95%)
+    tuned_rows = [
+        make_row(1, 'SELECT STATEMENT', cost=50),
+        make_row(2, 'TABLE ACCESS', 'BY INDEX ROWID', 'BIG_TABLE',
+                 parent_id=1, cost=50, depth=1),
+        make_row(3, 'INDEX', 'RANGE SCAN', 'BIG_IDX', parent_id=2,
+                 cost=5, depth=2),
+    ]
+
+    client = _make_client(orig_rows, tuned_rows=tuned_rows)
+    result = TuningValidator(client).validate(
+        'SELECT * FROM BIG_TABLE',
+        'SELECT /*+ INDEX(BIG_TABLE BIG_IDX) */ * FROM BIG_TABLE WHERE ID = 1',
+    )
+
+    assert result.verdict == 'APPROVE'
+    assert len(result.resolved_issues) > 0
+    assert len(result.new_issues) == 0
+    assert any('감소' in r for r in result.verdict_reasons)
+    assert any('신규 이슈 없음' in r for r in result.verdict_reasons)
+
+
+def test_auto_verdict_review():
+    """소폭 Cost 감소(-3%) + 이슈 변화 없음 → REVIEW"""
+    orig_rows = [make_row(1, 'SELECT STATEMENT', cost=100)]
+    tuned_rows = [make_row(1, 'SELECT STATEMENT', cost=97)]
+
+    client = _make_client(orig_rows, tuned_rows=tuned_rows)
+    result = TuningValidator(client).validate('SELECT 1 FROM DUAL', 'SELECT 1 FROM DUAL')
+
+    assert result.verdict == 'REVIEW'
+    assert result.cost_delta_pct == pytest.approx(-3.0)
+    assert len(result.verdict_reasons) > 0
+
+
+def test_auto_verdict_reject_cost_increase():
+    """비용 10% 초과 증가 → REJECT, 이유에 '증가' 포함"""
+    orig_rows = [make_row(1, 'SELECT STATEMENT', cost=100)]
+    tuned_rows = [make_row(1, 'SELECT STATEMENT', cost=150)]   # +50%
+
+    client = _make_client(orig_rows, tuned_rows=tuned_rows)
+    result = TuningValidator(client).validate('SELECT 1 FROM DUAL', 'SELECT 1 FROM DUAL')
+
+    assert result.verdict == 'REJECT'
+    assert any('증가' in r for r in result.verdict_reasons)

--- a/v2/ui/widgets/rewrite_tab.py
+++ b/v2/ui/widgets/rewrite_tab.py
@@ -8,10 +8,12 @@
 """
 from __future__ import annotations
 
+import webbrowser
+
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QGroupBox,
     QPlainTextEdit, QTextEdit, QPushButton, QLabel,
-    QApplication,
+    QApplication, QCheckBox, QFileDialog, QMessageBox,
 )
 from PyQt5.QtGui import QFont
 
@@ -19,6 +21,7 @@ from v2.core.rewrite.composite_rewriter import CompositeRewriter
 from v2.core.ai.ai_tuner import AiSqlTuner
 from v2.core.db.oracle_client import OracleClient
 from v2.core.pipeline.validation import ValidationResult
+from v2.core.report.tuning_report import TuningReporter
 from v2.ui.workers.ai_tune_worker import AiTuneWorker
 from v2.ui.workers.validate_worker import ValidateWorker
 from v2.ui.widgets.sql_editor import SqlHighlighter
@@ -41,6 +44,8 @@ class RewriteTab(QWidget):
         self._rewriter = CompositeRewriter()
         self._ai_worker: AiTuneWorker | None = None
         self._validate_worker: ValidateWorker | None = None
+        self._last_validation: ValidationResult | None = None
+        self._last_tuned_sql: str = ''
         self._current_sql: str = ''
         self._current_issues: list = []
         self._db_version: str = ''
@@ -180,6 +185,13 @@ class RewriteTab(QWidget):
         self._btn_ai_tune.clicked.connect(self._on_ai_tune_clicked)
         btn_row.addWidget(self._btn_ai_tune)
 
+        self._chk_measure_time = QCheckBox('실행시간 측정')
+        self._chk_measure_time.setToolTip(
+            '실제 SQL을 실행하여 원본/튜닝 SQL의 실행시간을 비교합니다\n'
+            '(SELECT / WITH 전용 — DML은 거부됩니다)'
+        )
+        btn_row.addWidget(self._chk_measure_time)
+
         self._btn_validate = QPushButton('검증 실행')
         self._btn_validate.setFixedWidth(100)
         self._btn_validate.setEnabled(False)
@@ -202,6 +214,17 @@ class RewriteTab(QWidget):
             '[검증 실행] 버튼을 클릭하면 원본 SQL과 AI 튜닝 SQL의 실행 계획을 비교합니다.'
         )
         vbox.addWidget(self._validation_text)
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        self._btn_save_report = QPushButton('리포트 저장')
+        self._btn_save_report.setFixedWidth(110)
+        self._btn_save_report.setEnabled(False)
+        self._btn_save_report.setToolTip('검증 결과를 HTML 리포트로 저장하고 브라우저에서 엽니다')
+        self._btn_save_report.clicked.connect(self._on_save_report_clicked)
+        btn_row.addWidget(self._btn_save_report)
+        vbox.addLayout(btn_row)
+
         return group
 
     # ── 규칙 재작성 ──────────────────────────────
@@ -269,14 +292,22 @@ class RewriteTab(QWidget):
         self._btn_validate.setText('검증 중...')
         self._validation_text.setPlainText('검증 중입니다...')
 
-        self._validate_worker = ValidateWorker(self._client, self._current_sql, tuned_sql)
+        self._validate_worker = ValidateWorker(
+            self._client,
+            self._current_sql,
+            tuned_sql,
+            measure_time=self._chk_measure_time.isChecked(),
+        )
         self._validate_worker.finished.connect(self._on_validate_done)
         self._validate_worker.error.connect(self._on_validate_error)
         self._validate_worker.start()
 
     def _on_validate_done(self, result: ValidationResult):
+        self._last_validation = result
+        self._last_tuned_sql = self._ai_sql_edit.toPlainText().strip()
         self._btn_validate.setEnabled(True)
         self._btn_validate.setText('검증 실행')
+        self._btn_save_report.setEnabled(result.is_valid)
         self._display_validation(result)
 
     def _on_validate_error(self, msg: str):
@@ -284,29 +315,81 @@ class RewriteTab(QWidget):
         self._btn_validate.setText('검증 실행')
         self._validation_text.setPlainText(f'[검증 오류]\n{msg}')
 
+    # 판정별 배경/글자 색상
+    _VERDICT_STYLE: dict[str, tuple[str, str]] = {
+        'APPROVE': ('#d4edda', '#155724'),   # 초록
+        'REVIEW':  ('#fff3cd', '#856404'),   # 노랑
+        'REJECT':  ('#f8d7da', '#721c24'),   # 빨강
+    }
+
     def _display_validation(self, r: ValidationResult):
-        lines = [r.verdict_label, '']
+        bg, fg = self._VERDICT_STYLE.get(r.verdict, ('#ffffff', '#000000'))
+
+        # ── 판정 헤더 (색상 배경) ──
+        reasons_html = '  /  '.join(r.verdict_reasons) if r.verdict_reasons else ''
+        header = (
+            f'<div style="background:{bg};color:{fg};padding:6px 8px;'
+            f'border-radius:4px;font-weight:bold;">'
+            f'{r.verdict_label}'
+            f'{"<br/><span style=\'font-weight:normal;font-size:0.9em\'>" + reasons_html + "</span>" if reasons_html else ""}'
+            f'</div>'
+        )
+
+        # ── 본문 ──
+        body_lines: list[str] = []
 
         if r.is_valid:
-            lines.append(r.cost_summary)
-            lines.append('')
+            body_lines.append(r.cost_summary)
+            if r.original_elapsed_ms is not None:
+                body_lines.append(r.elapsed_summary)
+            body_lines.append('')
 
             if r.resolved_issues:
-                lines.append(f'해결된 이슈 ({len(r.resolved_issues)}건):')
+                body_lines.append(f'해결된 이슈 ({len(r.resolved_issues)}건):')
                 for i in r.resolved_issues:
-                    lines.append(f'  ✓ [{i.severity}] {i.title}')
-                lines.append('')
+                    body_lines.append(f'  ✓ [{i.severity}] {i.title}')
+                body_lines.append('')
 
             if r.new_issues:
-                lines.append(f'새로 생긴 이슈 ({len(r.new_issues)}건):')
+                body_lines.append(f'새로 생긴 이슈 ({len(r.new_issues)}건):')
                 for i in r.new_issues:
-                    lines.append(f'  ! [{i.severity}] {i.title}')
+                    body_lines.append(f'  ! [{i.severity}] {i.title}')
         else:
-            lines.append(r.error_message)
+            body_lines.append(r.error_message)
 
-        self._validation_text.setPlainText('\n'.join(lines))
+        body_html = '<pre style="margin:6px 0 0 0;">' + '\n'.join(body_lines) + '</pre>'
+        self._validation_text.setHtml(header + body_html)
 
     def _clear_validation(self):
         self._validation_text.clear()
+        self._last_validation = None
+        self._last_tuned_sql = ''
         self._btn_validate.setEnabled(False)
         self._btn_validate.setText('검증 실행')
+        self._btn_save_report.setEnabled(False)
+
+    # ── 리포트 저장 ───────────────────────────────
+
+    def _on_save_report_clicked(self):
+        if not self._last_validation or not self._current_sql:
+            return
+
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            '리포트 저장',
+            'tuning_report.html',
+            'HTML 파일 (*.html)',
+        )
+        if not path:
+            return
+
+        try:
+            TuningReporter().save_html(
+                path,
+                self._current_sql,
+                self._last_tuned_sql,
+                self._last_validation,
+            )
+            webbrowser.open(path)
+        except Exception as e:
+            QMessageBox.warning(self, '저장 오류', f'리포트 저장 중 오류가 발생했습니다.\n{e}')

--- a/v2/ui/workers/validate_worker.py
+++ b/v2/ui/workers/validate_worker.py
@@ -16,15 +16,26 @@ class ValidateWorker(QThread):
     finished = pyqtSignal(object)   # ValidationResult
     error = pyqtSignal(str)
 
-    def __init__(self, client: OracleClient, original_sql: str, tuned_sql: str):
+    def __init__(
+        self,
+        client: OracleClient,
+        original_sql: str,
+        tuned_sql: str,
+        measure_time: bool = False,
+    ):
         super().__init__()
         self._validator = TuningValidator(client)
         self._original_sql = original_sql
         self._tuned_sql = tuned_sql
+        self._measure_time = measure_time
 
     def run(self):
         try:
-            result = self._validator.validate(self._original_sql, self._tuned_sql)
+            result = self._validator.validate(
+                self._original_sql,
+                self._tuned_sql,
+                measure_time=self._measure_time,
+            )
             self.finished.emit(result)
         except Exception as e:
             self.error.emit(str(e))


### PR DESCRIPTION
…TML 리포트)

본문:

## 변경 사항

### core/pipeline/validation.py — TuningValidator 완성
- validate(original_sql, tuned_sql, measure_time=False) 구현
  - EXPLAIN PLAN 실행 → 루트 Cost 추출 → cost_delta_pct 계산
  - PlanIssue 목록 비교 → resolved_issues / new_issues 분리
  - measure_time=True 시 execute_sql()로 실제 실행시간(ms) 측정 (SELECT/WITH 전용 — DML은 내부 가드에서 거부)
- ValidationResult 데이터클래스 필드 추가
  - original/tuned_elapsed_ms, elapsed_delta_pct (실행시간)
  - row_count_match (행 수 일치 여부, 미검증 시 None)
  - verdict (APPROVE/REVIEW/REJECT) — __post_init__ 자동 계산
  - verdict_reasons (판정 근거 문자열 목록)
- _compute_auto_verdict() 모듈 수준 순수 함수로 분리
  - REJECT: 문법 오류 / 행 수 불일치 / cost >+10% / 신규 이슈
  - APPROVE: cost ≤-10% AND resolved_issues ≥1 AND 신규 이슈 없음
  - REVIEW: 그 외
- 기존 verdict 프로퍼티 → quality_verdict 로 리네임 (INVALID/IMPROVED/WARNING/REGRESSED/NEUTRAL 세분화 레이블 유지)

### core/report/tuning_report.py — 신규
- TuningReporter.generate_html(original_sql, tuned_sql, result) → str
- TuningReporter.save_html(path, ...) → None
- 인라인 CSS 단독 HTML — 섹션 구성: 요약(판정 배지 + SQL 나란히) / 성능 비교 테이블 / 이슈 분석(해소=초록, 신규=빨강) / 판정 근거

### ui/widgets/rewrite_tab.py
- "실행시간 측정" 체크박스 추가 (검증 실행 버튼 옆)
- 검증 결과 표시: setHtml() 기반 색상 배지 (APPROVE=초록 / REVIEW=노랑 / REJECT=빨강)
- "리포트 저장" 버튼 추가 → QFileDialog 경로 선택 → TuningReporter.save_html() → webbrowser.open()

### ui/workers/validate_worker.py
- measure_time: bool = False 파라미터 추가

### 테스트
- test_tuning_validator.py 신규 (13 cases) 전처리, Cost 비교, 자동 판정 APPROVE/REVIEW/REJECT, 실행시간, 세미콜론 처리
- test_tuning_report.py 신규 (4 cases) HTML 필수 섹션, REJECT 오류 표시, 조건부 행, 파일 저장

Total: 242 passed