### PR TITLE
refactor: 공유 상수 모듈 v2/core/constants.py 추출

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,20 @@
 
 ---
 
+## v2/core/constants.py
+
+공유 상수 모듈 — 여러 모듈에 중복 정의되던 상수를 단일 출처(single source of truth)로 일원화.
+
+- `SEVERITY_COLORS` : 심각도별 (fg, bg) 색상 딕셔너리 — UI 위젯에서 공통 사용
+- `NL_INNER_CARD_THRESHOLD` : Nested Loop Join 내부 집합 행 수 경고 기준 (50,000)
+- `NO_STATS_COST_THRESHOLD` / `HIGH_COST_MIN_ROOT` : 실행 계획 분석 임계값
+- `DISK_READS_HIGH` / `DISK_READS_MEDIUM` / `BUFFER_GETS_MEDIUM` : V$SQL I/O 임계값
+- `MYSTAT_*` : V$MYSTAT 세션 통계 임계값 (physical reads, logical reads, redo size)
+- `COST_DELTA_WARN_PCT` : 튜닝 검증 비용 변화율 기준 (10%)
+- `STALE_STATS_HIGH_DAYS` / `STALE_STATS_MEDIUM_DAYS` : 테이블 통계 경과일 기준 (30일 / 7일)
+
+---
+
 ## v2/core/db/models.py
 
 Oracle DB 관련 데이터 클래스 및 상수 정의.

--- a/v2/core/constants.py
+++ b/v2/core/constants.py
@@ -1,0 +1,43 @@
+"""
+공유 상수 모듈 — 단일 출처(single source of truth)
+
+여러 모듈에 중복 정의되던 색상·임계값 상수를 일원화한다.
+"""
+from __future__ import annotations
+
+# ── 심각도 색상 (fg, bg) ──────────────────────────────────────────────────────
+SEVERITY_COLORS: dict[str, tuple[str, str]] = {
+    'HIGH':   ('#CC0000', '#FFE0E0'),
+    'MEDIUM': ('#CC6600', '#FFF3E0'),
+    'LOW':    ('#887700', '#FFFFF0'),
+    'INFO':   ('#005599', '#E8F4FF'),
+}
+
+# ── 실행 계획 분석 임계값 ─────────────────────────────────────────────────────
+# Nested Loop Join 내부 집합 행 수 경고 기준
+NL_INNER_CARD_THRESHOLD = 50_000
+# 통계 부재 의심: cardinality=1이고 cost 가 이 값 초과 시 경고
+NO_STATS_COST_THRESHOLD = 100
+# High Cost Ratio 검사: root cost 가 이 값 이하면 건너뜀
+HIGH_COST_MIN_ROOT = 100
+
+# ── I/O 통계 임계값 ──────────────────────────────────────────────────────────
+DISK_READS_HIGH   = 1_000
+DISK_READS_MEDIUM = 100
+BUFFER_GETS_MEDIUM = 100_000
+
+# V$MYSTAT 세션 통계 임계값
+MYSTAT_PHYSICAL_READS_HIGH    = 1_000
+MYSTAT_PHYSICAL_READS_MEDIUM  = 100
+MYSTAT_LOGICAL_READS_HIGH     = 100_000
+MYSTAT_LOGICAL_READS_MEDIUM   = 10_000
+MYSTAT_REDO_SIZE_HIGH         = 1_000_000
+MYSTAT_REDO_SIZE_MEDIUM       = 100_000
+
+# ── 튜닝 검증 임계값 ─────────────────────────────────────────────────────────
+# 비용 변화율(%) 기준: 이 값 초과 시 REJECT, 이하(-) 시 APPROVE 후보
+COST_DELTA_WARN_PCT = 10
+
+# ── 테이블 통계 경과일 임계값 (stats_tab) ────────────────────────────────────
+STALE_STATS_HIGH_DAYS   = 30
+STALE_STATS_MEDIUM_DAYS = 7

--- a/v2/core/db/oracle_client.py
+++ b/v2/core/db/oracle_client.py
@@ -25,6 +25,12 @@ from .models import (
     WAIT_CLASS_SUGGESTION,
 )
 from .plan_executor import PlanExecutor
+from ..constants import (
+    DISK_READS_HIGH, DISK_READS_MEDIUM, BUFFER_GETS_MEDIUM,
+    MYSTAT_PHYSICAL_READS_HIGH, MYSTAT_PHYSICAL_READS_MEDIUM,
+    MYSTAT_LOGICAL_READS_HIGH, MYSTAT_LOGICAL_READS_MEDIUM,
+    MYSTAT_REDO_SIZE_HIGH, MYSTAT_REDO_SIZE_MEDIUM,
+)
 
 # 기존 import 경로 호환성 유지 (다른 파일 수정 불필요)
 __all__ = [
@@ -363,17 +369,17 @@ class OracleClient:
             cpu_ms         = row[3] or 0.0
             rows_processed = row[4] or 0
 
-            if disk_reads > 1000:
+            if disk_reads > DISK_READS_HIGH:
                 disk_sev  = 'HIGH'
                 disk_sugg = '물리적 디스크 읽기가 매우 많습니다. 인덱스를 추가하거나 Buffer Cache 크기를 검토하세요.'
-            elif disk_reads > 100:
+            elif disk_reads > DISK_READS_MEDIUM:
                 disk_sev  = 'MEDIUM'
                 disk_sugg = '디스크 읽기가 다소 발생합니다. 인덱스 효율을 확인하세요.'
             else:
                 disk_sev  = 'LOW'
                 disk_sugg = ''
 
-            buf_sev  = 'MEDIUM' if buffer_gets > 100_000 else 'INFO'
+            buf_sev  = 'MEDIUM' if buffer_gets > BUFFER_GETS_MEDIUM else 'INFO'
             buf_sugg = '논리적 읽기가 매우 많습니다. 인덱스 효율을 높이거나 결과셋을 줄이세요.' if buf_sev == 'MEDIUM' else ''
 
             return [
@@ -400,19 +406,19 @@ class OracleClient:
         stat_cfg = {
             'physical reads': {
                 'category': '세션 통계',
-                'hi': 1000, 'med': 100,
+                'hi': MYSTAT_PHYSICAL_READS_HIGH, 'med': MYSTAT_PHYSICAL_READS_MEDIUM,
                 'sugg_hi':  '물리적 디스크 읽기가 많습니다. 인덱스 추가 또는 Buffer Cache 확장을 검토하세요.',
                 'sugg_med': '디스크 읽기가 다소 발생합니다. 인덱스 효율을 확인하세요.',
             },
             'session logical reads': {
                 'category': '세션 통계',
-                'hi': 100_000, 'med': 10_000,
+                'hi': MYSTAT_LOGICAL_READS_HIGH, 'med': MYSTAT_LOGICAL_READS_MEDIUM,
                 'sugg_hi':  '논리적 읽기가 매우 많습니다. 실행 계획 및 인덱스를 검토하세요.',
                 'sugg_med': '논리적 읽기가 다소 많습니다.',
             },
             'redo size': {
                 'category': '세션 통계',
-                'hi': 1_000_000, 'med': 100_000,
+                'hi': MYSTAT_REDO_SIZE_HIGH, 'med': MYSTAT_REDO_SIZE_MEDIUM,
                 'sugg_hi':  'Redo 생성량이 많습니다. DML 배치 최적화를 검토하세요.',
                 'sugg_med': '',
             },

--- a/v2/core/db/plan_analyzer.py
+++ b/v2/core/db/plan_analyzer.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Optional
 from .oracle_client import PlanRow
+from ..constants import NL_INNER_CARD_THRESHOLD, NO_STATS_COST_THRESHOLD, HIGH_COST_MIN_ROOT
 
 
 # 심각도 레벨
@@ -246,7 +247,7 @@ class PlanAnalyzer:
         """단일 노드의 Cost가 전체의 70% 이상이면 HIGH로 보고"""
         # 루트 노드(parent_id가 None)의 cost를 전체 비용으로 사용
         root = next((r for r in self.rows if r.parent_id is None), None)
-        if root is None or root.cost is None or root.cost <= 100:
+        if root is None or root.cost is None or root.cost <= HIGH_COST_MIN_ROOT:
             return
         total_cost = root.cost
 
@@ -282,7 +283,7 @@ class PlanAnalyzer:
                         children_cards.append(child.cardinality)
                 if len(children_cards) >= 2:
                     inner_card = max(children_cards)
-                    if inner_card > 50_000:
+                    if inner_card > NL_INNER_CARD_THRESHOLD:
                         self._issues.append(PlanIssue(
                             severity=SEVERITY_MEDIUM,
                             category='Join 방식',
@@ -305,7 +306,7 @@ class PlanAnalyzer:
             if (row.operation == 'TABLE ACCESS'
                     and row.object_name
                     and row.cardinality == 1
-                    and row.cost is not None and row.cost > 100):
+                    and row.cost is not None and row.cost > NO_STATS_COST_THRESHOLD):
                 no_stat_tables.append(row.object_name)
 
         if no_stat_tables:

--- a/v2/core/pipeline/validation.py
+++ b/v2/core/pipeline/validation.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from ..db.oracle_client import OracleClient
 from ..db.plan_analyzer import PlanAnalyzer, PlanIssue
+from ..constants import COST_DELTA_WARN_PCT
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -52,7 +53,7 @@ def _compute_auto_verdict(r: 'ValidationResult') -> tuple[str, list[str]]:
         reject_reasons.append('문법 오류 — 실행 불가')
     if r.row_count_match is False:
         reject_reasons.append('결과 행 수 불일치')
-    if r.cost_delta_pct is not None and r.cost_delta_pct > 10:
+    if r.cost_delta_pct is not None and r.cost_delta_pct > COST_DELTA_WARN_PCT:
         reject_reasons.append(f'비용 +{r.cost_delta_pct:.1f}% 증가')
     if r.new_issues:
         reject_reasons.append(f'신규 이슈 {len(r.new_issues)}건 발생')
@@ -61,7 +62,7 @@ def _compute_auto_verdict(r: 'ValidationResult') -> tuple[str, list[str]]:
         return 'REJECT', reject_reasons
 
     # ── APPROVE ───────────────────────────────────────────────────
-    cost_ok = r.cost_delta_pct is not None and r.cost_delta_pct <= -10
+    cost_ok = r.cost_delta_pct is not None and r.cost_delta_pct <= -COST_DELTA_WARN_PCT
     resolved_ok = len(r.resolved_issues) >= 1
     row_ok = r.row_count_match is not False   # True 또는 None(미검증) 허용
 

--- a/v2/ui/widgets/index_tab.py
+++ b/v2/ui/widgets/index_tab.py
@@ -16,12 +16,7 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtGui import QColor, QFont
 from PyQt5.QtCore import Qt
 
-
-_SEVERITY_COLORS = {
-    'HIGH':   ('#CC0000', '#FFE0E0'),
-    'MEDIUM': ('#CC6600', '#FFF3E0'),
-    'INFO':   ('#005599', '#E8F4FF'),
-}
+from v2.core.constants import SEVERITY_COLORS as _SEVERITY_COLORS
 
 _PLACEHOLDER_STYLE = (
     'color: #888888; font-size: 13px; '

--- a/v2/ui/widgets/issues_tab.py
+++ b/v2/ui/widgets/issues_tab.py
@@ -11,13 +11,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import QFont, QColor
 
-
-_SEVERITY_COLORS = {
-    'HIGH':   ('#CC0000', '#FFE0E0'),
-    'MEDIUM': ('#CC6600', '#FFF3E0'),
-    'LOW':    ('#887700', '#FFFFF0'),
-    'INFO':   ('#005599', '#E8F4FF'),
-}
+from v2.core.constants import SEVERITY_COLORS as _SEVERITY_COLORS
 
 
 class IssuesTab(QWidget):

--- a/v2/ui/widgets/stats_tab.py
+++ b/v2/ui/widgets/stats_tab.py
@@ -15,6 +15,7 @@ from PyQt5.QtGui import QColor
 from PyQt5.QtCore import Qt
 
 from v2.core.db.oracle_client import OracleClient
+from v2.core.constants import STALE_STATS_HIGH_DAYS, STALE_STATS_MEDIUM_DAYS
 
 # 경과일 기준 색상
 _COLOR_RED    = QColor('#FFCCCC')
@@ -168,10 +169,10 @@ class StatsTab(QWidget):
             if info.last_analyzed is None:
                 status_str = '미수집'
                 bg = _COLOR_RED
-            elif days is not None and days > 30:
+            elif days is not None and days > STALE_STATS_HIGH_DAYS:
                 status_str = f'{days}일 경과 (HIGH)'
                 bg = _COLOR_RED
-            elif days is not None and days > 7:
+            elif days is not None and days > STALE_STATS_MEDIUM_DAYS:
                 status_str = f'{days}일 경과 (MEDIUM)'
                 bg = _COLOR_ORANGE
             else:

--- a/v2/ui/widgets/wait_event_tab.py
+++ b/v2/ui/widgets/wait_event_tab.py
@@ -20,13 +20,7 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtGui import QColor, QFont
 from PyQt5.QtCore import Qt
 
-
-_SEVERITY_COLORS = {
-    'HIGH':   ('#CC0000', '#FFE0E0'),
-    'MEDIUM': ('#CC6600', '#FFF3E0'),
-    'LOW':    ('#887700', '#FFFFF0'),
-    'INFO':   ('#005599', '#E8F4FF'),
-}
+from v2.core.constants import SEVERITY_COLORS as _SEVERITY_COLORS
 
 _METHOD_STYLES = {
     'V$SESSION_WAIT 기준': ('color:#004400; background:#E8FFE8; border:1px solid #66AA66;'),


### PR DESCRIPTION
## Summary
- `v2/core/constants.py` 신규 생성 — 단일 출처(single source of truth) 확보
- `_SEVERITY_COLORS` 3중 정의 제거 (`issues_tab`, `index_tab`, `wait_event_tab`)
- `index_tab.py`의 `LOW` 키 누락 버그 수정
- 임계값 magic number 상수화 (`plan_analyzer`, `oracle_client`, `validation`, `stats_tab`)

## Test plan
- [x] 242 tests passed (`python -m pytest v2/tests/ -x -q`)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)